### PR TITLE
Issue #82 - Add support for Initial Access Intelligence Rules

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -4,6 +4,8 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 	"github.com/vulncheck-oss/cli/pkg/cmd/about"
@@ -13,6 +15,7 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/cmd/index"
 	"github.com/vulncheck-oss/cli/pkg/cmd/indices"
 	"github.com/vulncheck-oss/cli/pkg/cmd/purl"
+	"github.com/vulncheck-oss/cli/pkg/cmd/rule"
 	"github.com/vulncheck-oss/cli/pkg/cmd/scan"
 	"github.com/vulncheck-oss/cli/pkg/cmd/version"
 	"github.com/vulncheck-oss/cli/pkg/config"
@@ -21,7 +24,6 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
 	"github.com/vulncheck-oss/sdk"
-	"os"
 )
 
 type AuthError struct {
@@ -77,6 +79,7 @@ func NewCmdRoot() *cobra.Command {
 	cmd.AddCommand(cpe.Command())
 	cmd.AddCommand(purl.Command())
 	cmd.AddCommand(scan.Command())
+	cmd.AddCommand(rule.Command())
 
 	return cmd
 }

--- a/pkg/cmd/rule/rule.go
+++ b/pkg/cmd/rule/rule.go
@@ -45,7 +45,7 @@ func Command() *cobra.Command {
 			}
 
 			if opts.Table {
-				if err := ui.RuleResults(rulesList); err != nil {
+				if err := ui.SingleColumnResults(rulesList, "Results"); err != nil {
 					return err
 				}
 

--- a/pkg/cmd/rule/rule.go
+++ b/pkg/cmd/rule/rule.go
@@ -19,7 +19,8 @@ type Options struct {
 func Command() *cobra.Command {
 
 	opts := &Options{
-		Json: false,
+		Json:  false,
+		Table: false,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/rule/rule.go
+++ b/pkg/cmd/rule/rule.go
@@ -1,0 +1,62 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/vulncheck-oss/cli/pkg/config"
+	"github.com/vulncheck-oss/cli/pkg/i18n"
+	"github.com/vulncheck-oss/cli/pkg/session"
+	"github.com/vulncheck-oss/cli/pkg/ui"
+)
+
+type Options struct {
+	Json  bool
+	Table bool
+}
+
+func Command() *cobra.Command {
+
+	opts := &Options{
+		Json: false,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "rule <rule>",
+		Short:   i18n.C.RuleShort,
+		Example: fmt.Sprintf(i18n.C.RuleExample, "snort", "suricata"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return ui.Error(i18n.C.RuleErrorRuleNameRequired)
+			}
+
+			response, err := session.Connect(config.Token()).GetRule(args[0])
+			if err != nil {
+				return err
+			}
+
+			rulesList := strings.Split(response, "\n")
+
+			if opts.Json {
+				ui.Json(rulesList)
+				return nil
+			}
+
+			if opts.Table {
+				ui.RuleResults(rulesList)
+				return nil
+			}
+
+			// default output
+			fmt.Println(response)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Json, "json", "j", false, "Output as JSON")
+	cmd.Flags().BoolVarP(&opts.Table, "table", "t", false, "Output as Table")
+
+	return cmd
+}

--- a/pkg/cmd/rule/rule.go
+++ b/pkg/cmd/rule/rule.go
@@ -45,7 +45,10 @@ func Command() *cobra.Command {
 			}
 
 			if opts.Table {
-				ui.RuleResults(rulesList)
+				if err := ui.RuleResults(rulesList); err != nil {
+					return err
+				}
+
 				return nil
 			}
 

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -62,6 +62,11 @@ type Copy struct {
 	PurlVulnsFound          string
 	PurlErrorSchemeRequired string
 
+	RuleShort                 string
+	RuleErrorRequired         string
+	RuleExample               string
+	RuleErrorRuleNameRequired string
+
 	ScanShort                  string
 	ScanExample                string
 	ScanErrorDirectoryRequired string
@@ -164,6 +169,11 @@ var En = Copy{
 	PurlNoVulns:    "No Vulnerabilities were found for purl %s",
 	PurlVulnFound:  "1 Vulnerability were found for purl %s",
 	PurlVulnsFound: "%d Vulnerabilities were found for purl %s",
+
+	RuleShort:                 "Look up a specified rule for Initial Access Intelligence",
+	RuleErrorRequired:         "rule name is required",
+	RuleExample:               "vci rule \"%s\" \nvci rule \"%s\"",
+	RuleErrorRuleNameRequired: "rule name is required",
 
 	ScanShort:   "Scan a directory for vulnerabilities",
 	ScanExample: "vci scan /path/to/directory",

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -9,7 +11,6 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/models"
 	"github.com/vulncheck-oss/sdk"
 	"golang.org/x/term"
-	"strings"
 )
 
 var baseStyle = lipgloss.NewStyle().
@@ -183,6 +184,20 @@ func ScanResults(results []models.ScanResultVulnerabilities) error {
 		}
 
 		t.Row(result.CVE, result.Name, result.Version, inKev, result.CVSSBaseScore, result.CVSSTemporalScore, result.FixedVersions)
+	}
+
+	fmt.Println(t)
+	return nil
+}
+
+func RuleResults(results []string) error {
+	t := ltable.New().
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("#6667ab"))).
+		Headers("Results").
+		Width(TermWidth())
+
+	for _, result := range results {
+		t.Row(result)
 	}
 
 	fmt.Println(t)

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -190,10 +190,10 @@ func ScanResults(results []models.ScanResultVulnerabilities) error {
 	return nil
 }
 
-func RuleResults(results []string) error {
+func SingleColumnResults(results []string, title string) error {
 	t := ltable.New().
 		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("#6667ab"))).
-		Headers("Results").
+		Headers(title).
 		Width(TermWidth())
 
 	for _, result := range results {


### PR DESCRIPTION
resolves #82
Example of commands
```sh
vci rule snort
vci rule snort --table 
vci rule snort --json
```

> example results as table:

![image](https://github.com/user-attachments/assets/dcb076a9-9822-48b5-875a-21ea7994f99c)
