### PR TITLE
Update go.mod and go.sum for vulncheck-oss/sdk-go v1.6.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
-	github.com/vulncheck-oss/sdk v1.6.2
+	github.com/vulncheck-oss/sdk-go v1.6.3
 	golang.org/x/term v0.23.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -802,8 +802,8 @@ github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RV
 github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=
 github.com/vifraa/gopom v1.0.0 h1:L9XlKbyvid8PAIK8nr0lihMApJQg/12OBvMA28BcWh0=
 github.com/vifraa/gopom v1.0.0/go.mod h1:oPa1dcrGrtlO37WPDBm5SqHAT+wTgF8An1Q71Z6Vv4o=
-github.com/vulncheck-oss/sdk v1.6.2 h1:yp3Pj0EK3izRBzEv5Jqj6GudhRO8ExwKdpD5hN/AOpg=
-github.com/vulncheck-oss/sdk v1.6.2/go.mod h1:z7vEA/CRPu6K7uWLXMXzyIzVncSUeEN8w1L1nakspds=
+github.com/vulncheck-oss/sdk-go v1.6.3 h1:qJ3WDLE5bUvvNxLG4C/oeOVwcwZXBJCezfHxP6W35oo=
+github.com/vulncheck-oss/sdk-go v1.6.3/go.mod h1:kdHFpGsY8UYHuq/dOU7cGOdCelGbwbYx29AMvc8esZw=
 github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651 h1:jIVmlAFIqV3d+DOxazTR9v+zgj8+VYuQBzPgBZvWBHA=
 github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651/go.mod h1:b26F2tHLqaoRQf8DywqzVaV1MQ9yvjb0OMcNl7Nxu20=
 github.com/wagoodman/go-progress v0.0.0-20230925121702-07e42b3cdba0 h1:0KGbf+0SMg+UFy4e1A/CPVvXn21f1qtWdeJwxZFoQG8=

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -2,12 +2,13 @@ package logout
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/i18n"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
-	"github.com/vulncheck-oss/sdk"
+	"github.com/vulncheck-oss/sdk-go"
 )
 
 func Command() *cobra.Command {

--- a/pkg/cmd/index/index.go
+++ b/pkg/cmd/index/index.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
 	"github.com/vulncheck-oss/cli/pkg/utils"
-	"github.com/vulncheck-oss/sdk"
+	"github.com/vulncheck-oss/sdk-go"
 )
 
 func Command() *cobra.Command {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -4,8 +4,9 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"github.com/vulncheck-oss/cli/pkg/cmd/token"
 	"os"
+
+	"github.com/vulncheck-oss/cli/pkg/cmd/token"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/i18n"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
-	"github.com/vulncheck-oss/sdk"
+	"github.com/vulncheck-oss/sdk-go"
 )
 
 type AuthError struct {

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -3,6 +3,9 @@ package scan
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/charmbracelet/bubbles/progress"
@@ -13,10 +16,8 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/models"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
-	"github.com/vulncheck-oss/sdk"
-	"github.com/vulncheck-oss/sdk/pkg/client"
-	"strings"
-	"time"
+	"github.com/vulncheck-oss/sdk-go"
+	"github.com/vulncheck-oss/sdk-go/pkg/client"
 )
 
 type Options struct {

--- a/pkg/cmd/token/token.go
+++ b/pkg/cmd/token/token.go
@@ -3,6 +3,9 @@ package token
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"text/tabwriter"
+
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
@@ -10,9 +13,7 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/i18n"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
-	"github.com/vulncheck-oss/sdk"
-	"os"
-	"text/tabwriter"
+	"github.com/vulncheck-oss/sdk-go"
 )
 
 func Command() *cobra.Command {

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -2,12 +2,13 @@ package login
 
 import (
 	"fmt"
+
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/huh/spinner"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
-	"github.com/vulncheck-oss/sdk"
+	"github.com/vulncheck-oss/sdk-go"
 )
 
 func ChooseAuthMethod() (string, error) {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2,13 +2,14 @@ package session
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/vulncheck-oss/cli/internal/build"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/environment"
-	"github.com/vulncheck-oss/sdk"
-	"regexp"
-	"strings"
+	"github.com/vulncheck-oss/sdk-go"
 )
 
 type MeResponse struct {

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -10,7 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	ltable "github.com/charmbracelet/lipgloss/table"
 	"github.com/vulncheck-oss/cli/pkg/models"
-	"github.com/vulncheck-oss/sdk"
+	"github.com/vulncheck-oss/sdk-go"
 	"golang.org/x/term"
 )
 


### PR DESCRIPTION
replaces import from https://github.com/vulncheck-oss/sdk-go name change