### PR TITLE
Build self-upgrade command

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -4,8 +4,9 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"github.com/vulncheck-oss/cli/pkg/cmd/offline"
 	"os"
+
+	"github.com/vulncheck-oss/cli/pkg/cmd/offline"
 
 	"github.com/vulncheck-oss/cli/pkg/cmd/token"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/cmd/purl"
 	"github.com/vulncheck-oss/cli/pkg/cmd/rule"
 	"github.com/vulncheck-oss/cli/pkg/cmd/scan"
+	"github.com/vulncheck-oss/cli/pkg/cmd/selfupgrade"
 	"github.com/vulncheck-oss/cli/pkg/cmd/tag"
 	"github.com/vulncheck-oss/cli/pkg/cmd/version"
 	"github.com/vulncheck-oss/cli/pkg/config"
@@ -79,6 +81,7 @@ func NewCmdRoot() *cobra.Command {
 	cmd.AddCommand(about.Command())
 	cmd.AddCommand(auth.Command())
 	cmd.AddCommand(token.Command())
+	cmd.AddCommand(selfupgrade.Command())
 	cmd.AddCommand(indices.Command())
 	cmd.AddCommand(index.Command())
 	cmd.AddCommand(backup.Command())

--- a/pkg/cmd/selfupgrade/selfupgrade.go
+++ b/pkg/cmd/selfupgrade/selfupgrade.go
@@ -1,0 +1,358 @@
+package selfupgrade
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-version"
+	"github.com/spf13/cobra"
+	"github.com/vulncheck-oss/cli/internal/build"
+	"github.com/vulncheck-oss/cli/pkg/i18n"
+	"github.com/vulncheck-oss/cli/pkg/session"
+)
+
+type Release struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+func Command() *cobra.Command {
+	var force bool
+	var version string
+
+	cmd := &cobra.Command{
+		Use:   "self-upgrade",
+		Short: i18n.C.SelfUpgradeShort,
+		Long:  i18n.C.SelfUpgradeLong,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSelfUpgrade(force, version)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force upgrade even if already on the latest version")
+	cmd.Flags().StringVarP(&version, "version", "v", "", "Upgrade to a specific version (e.g., 1.0.0)")
+
+	session.DisableAuthCheck(cmd)
+	return cmd
+}
+
+func runSelfUpgrade(force bool, targetVersion string) error {
+	currentVersion := strings.TrimPrefix(build.Version, "v")
+
+	release, err := getLatestRelease()
+	if err != nil {
+		return fmt.Errorf("failed to fetch latest release: %v", err)
+	}
+
+	latestVersion := strings.TrimPrefix(release.TagName, "v")
+
+	// If cli arg passes a specific version validate and use it
+	if targetVersion != "" {
+		targetVersion = strings.TrimPrefix(targetVersion, "v")
+		latestVersion = targetVersion
+		release.TagName = "v" + targetVersion
+	}
+
+	// Check if we need to upgrade
+	if !force && targetVersion == "" {
+		currentV, err := version.NewVersion(currentVersion)
+		if err != nil {
+			return fmt.Errorf("invalid current version: %v", err)
+		}
+
+		latestV, err := version.NewVersion(latestVersion)
+		if err != nil {
+			return fmt.Errorf("invalid latest version: %v", err)
+		}
+
+		if !latestV.GreaterThan(currentV) {
+			fmt.Printf("✅ Already on the latest version (%s)\n", currentVersion)
+			return nil
+		}
+	}
+
+	fmt.Printf("🔄 Upgrading from %s to %s...\n", currentVersion, latestVersion)
+
+	// Determine platform-specific assets
+	assetName, err := getPlatformAssetName(latestVersion)
+	if err != nil {
+		return fmt.Errorf("failed to determine platform asset: %v", err)
+	}
+
+	var downloadURL string
+	for _, asset := range release.Assets {
+		if asset.Name == assetName {
+			downloadURL = asset.BrowserDownloadURL
+			break
+		}
+	}
+
+	if downloadURL == "" {
+		return fmt.Errorf("asset %s not found in release %s", assetName, release.TagName)
+	}
+
+	if err := downloadAndInstall(downloadURL, assetName); err != nil {
+		return fmt.Errorf("failed to download and install: %v", err)
+	}
+
+	fmt.Printf("✅ Successfully upgraded to version %s!\n", latestVersion)
+	fmt.Printf("🔗 Changelog: https://github.com/vulncheck-oss/cli/releases/tag/v%s\n", latestVersion)
+
+	return nil
+}
+
+func getLatestRelease() (*Release, error) {
+	resp, err := http.Get("https://api.github.com/repos/vulncheck-oss/cli/releases/latest")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+
+	return &release, nil
+}
+
+func getPlatformAssetName(version string) (string, error) {
+	var os, arch, ext string
+
+	switch runtime.GOOS {
+	case "darwin":
+		os = "macOS"
+		ext = "zip"
+	case "linux":
+		os = "linux"
+		ext = "tar.gz"
+	case "windows":
+		os = "windows"
+		ext = "zip"
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = "amd64"
+	case "arm64":
+		arch = "arm64"
+	default:
+		return "", fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+	}
+
+	return fmt.Sprintf("vulncheck_%s_%s_%s.%s", version, os, arch, ext), nil
+}
+
+func downloadAndInstall(downloadURL, filename string) error {
+	// Create temporary directory
+	tempDir, err := os.MkdirTemp("", "vulncheck-upgrade-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Download file
+	fmt.Printf("📥 Downloading %s...\n", filename)
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	tempFile := filepath.Join(tempDir, filename)
+	out, err := os.Create(tempFile)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("📦 Extracting %s...\n", filename)
+	binaryPath, err := extractArchive(tempFile, tempDir)
+	if err != nil {
+		return err
+	}
+
+	// Get current executable path
+	currentExe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	// Get the real path (resolve symlinks)
+	currentExe, err = filepath.EvalSymlinks(currentExe)
+	if err != nil {
+		return err
+	}
+
+	// Create backup of current binary
+	backupPath := currentExe + ".backup." + fmt.Sprintf("%d", time.Now().Unix())
+	if err := copyFile(currentExe, backupPath); err != nil {
+		return fmt.Errorf("failed to create backup: %v", err)
+	}
+
+	fmt.Printf("💾 Created backup at %s\n", backupPath)
+
+	// Replace current binary
+	fmt.Printf("🔧 Installing new binary...\n")
+	if err := copyFile(binaryPath, currentExe); err != nil {
+		// Restore backup on failure
+		copyFile(backupPath, currentExe)
+		return fmt.Errorf("failed to install new binary: %v", err)
+	}
+
+	// Make executable (Unix systems)
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(currentExe, 0755); err != nil {
+			return fmt.Errorf("failed to set executable permissions: %v", err)
+		}
+	}
+
+	// Remove backup file after successful installation
+	os.Remove(backupPath)
+
+	return nil
+}
+
+func extractArchive(archivePath, destDir string) (string, error) {
+	var binaryName string
+	if runtime.GOOS == "windows" {
+		binaryName = "vulncheck.exe"
+	} else {
+		binaryName = "vulncheck"
+	}
+
+	if strings.HasSuffix(archivePath, ".zip") {
+		return extractZip(archivePath, destDir, binaryName)
+	} else if strings.HasSuffix(archivePath, ".tar.gz") {
+		return extractTarGz(archivePath, destDir, binaryName)
+	}
+
+	return "", fmt.Errorf("unsupported archive format")
+}
+
+func extractZip(zipPath, destDir, binaryName string) (string, error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if filepath.Base(f.Name) == binaryName {
+			rc, err := f.Open()
+			if err != nil {
+				return "", err
+			}
+			defer rc.Close()
+
+			binaryPath := filepath.Join(destDir, binaryName)
+			outFile, err := os.OpenFile(binaryPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return "", err
+			}
+			defer outFile.Close()
+
+			_, err = io.Copy(outFile, rc)
+			if err != nil {
+				return "", err
+			}
+
+			return binaryPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("binary %s not found in zip archive", binaryName)
+}
+
+func extractTarGz(tarPath, destDir, binaryName string) (string, error) {
+	file, err := os.Open(tarPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return "", err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+
+		if filepath.Base(header.Name) == binaryName && header.Typeflag == tar.TypeReg {
+			binaryPath := filepath.Join(destDir, binaryName)
+			outFile, err := os.Create(binaryPath)
+			if err != nil {
+				return "", err
+			}
+			defer outFile.Close()
+
+			_, err = io.Copy(outFile, tr)
+			if err != nil {
+				return "", err
+			}
+
+			return binaryPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("binary %s not found in tar.gz archive", binaryName)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+
+	return out.Sync()
+}

--- a/pkg/cmd/selfupgrade/selfupgrade_test.go
+++ b/pkg/cmd/selfupgrade/selfupgrade_test.go
@@ -1,0 +1,45 @@
+package selfupgrade
+
+import (
+	"testing"
+)
+
+func TestGetPlatformAssetName(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected string
+	}{
+		{
+			name:     "version 1.0.0",
+			version:  "1.0.0",
+			expected: "vulncheck_1.0.0_macOS_arm64.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getPlatformAssetName(tt.version)
+			if err != nil {
+				t.Fatalf("getPlatformAssetName() error = %v", err)
+			}
+
+			if len(result) == 0 {
+				t.Errorf("getPlatformAssetName() returned empty string")
+			}
+			// Should contain version
+			if !contains(result, tt.version) {
+				t.Errorf("getPlatformAssetName() = %v, should contain version %v", result, tt.version)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -129,6 +129,9 @@ type Copy struct {
 	ScanNoCvesFound string
 	ScanBenchmark   string
 
+	SelfUpgradeShort string
+	SelfUpgradeLong  string
+
 	ErrorNoToken      string
 	ErrorUnauthorized string
 }
@@ -282,6 +285,12 @@ var En = Copy{
 	ScanNoCvesFound:            "No vulnerabilities found in %d packages",
 	ScanBenchmark:              "Scan completed in %s",
 	ScanErrorDirectoryRequired: "Error: Directory is required",
+
+	SelfUpgradeShort: "Upgrade the vulncheck CLI to the latest version",
+	SelfUpgradeLong: heredoc.Doc(`
+			Upgrade the vulncheck CLI to the latest version by downloading
+			and installing the appropriate binary for your platform from GitHub releases.
+		`),
 
 	ErrorUnauthorized: "Error: Unauthorized, Try authenticating with: vulncheck auth login",
 	ErrorNoToken:      "No token found. Please run `vulncheck auth login` to authenticate or populate the environment variable `VC_TOKEN`.",


### PR DESCRIPTION
# VulnCheck CLI Self-Upgrade Command

The `vulncheck self-upgrade` command allows users to automatically update their CLI installation to the latest version directly from GitHub releases.

## Usage

```bash
# Upgrade to latest version (only if newer than current)
vulncheck self-upgrade

# Force upgrade even if already on latest
vulncheck self-upgrade --force

# Upgrade to specific version
vulncheck self-upgrade --version 1.0.0
```
