### PR TITLE
🚧 this will look for a CPE in the sbom LinuxDistribution artifact

### DIFF
--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -141,6 +141,17 @@ func GetCPEDetail(sbm *sbom.SBOM) []string {
 	var cpes []string
 	seen := make(map[string]struct{})
 
+	if sbm.Artifacts.LinuxDistribution != nil && sbm.Artifacts.LinuxDistribution.CPEName != "" {
+		cpeStr := strings.TrimSpace(sbm.Artifacts.LinuxDistribution.CPEName)
+		norm := cpeutils.NormalizeCPEString(cpeStr)
+		if !strings.Contains(cpeStr, ".github/workflows") {
+			if _, exists := seen[norm]; !exists {
+				cpes = append(cpes, cpeStr)
+				seen[norm] = struct{}{}
+			}
+		}
+	}
+
 	for p := range sbm.Artifacts.Packages.Enumerate() {
 		if len(p.CPEs) > 0 {
 			for _, cpe := range p.CPEs {


### PR DESCRIPTION
Not quite sure on the overall impact, but this is a way to add on other CPEs not inside `Artifacts.Packages`