### PR TITLE
Add index argument validation and suggestion

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6,11 +6,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"slices"
+
 	"github.com/fumeapp/taskin"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/utils"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/cmd/backup/backup.go
+++ b/pkg/cmd/backup/backup.go
@@ -2,14 +2,47 @@ package backup
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/i18n"
+	"github.com/vulncheck-oss/cli/pkg/sdk"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
 	"github.com/vulncheck-oss/cli/pkg/utils"
 )
+
+func validateIndex(index string) (*sdk.Client, error) {
+	client := session.Connect(config.Token())
+	indicesResponse, err := client.GetIndices()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a map of indices to compare against
+	var indexNames []string
+	available := make(map[string]bool)
+	for _, idx := range indicesResponse.GetData() {
+		available[idx.Name] = true
+		indexNames = append(indexNames, idx.Name)
+	}
+
+	// If the index is not present in the map, print output and suggest
+	// options for what the argument may have intended
+	if !available[index] {
+		var msg strings.Builder
+		fmt.Fprintf(&msg, "index '%s' does not exist", index)
+		if suggestions := utils.SuggestFor(index, indexNames); len(suggestions) > 0 {
+			msg.WriteString("\n\nDid you mean this?\n")
+			for _, s := range suggestions {
+				fmt.Fprintf(&msg, "\t%s\n", s)
+			}
+		}
+		return nil, fmt.Errorf("%s", msg.String())
+	}
+	return client, nil
+}
 
 type UrlOptions struct {
 	Json bool
@@ -33,10 +66,17 @@ func Command() *cobra.Command {
 			if len(args) != 1 {
 				return ui.Error("index name is required")
 			}
-			response, err := session.Connect(config.Token()).GetIndexBackup(args[0])
+
+			client, err := validateIndex(args[0])
 			if err != nil {
 				return err
 			}
+
+			response, err := client.GetIndexBackup(args[0])
+			if err != nil {
+				return err
+			}
+
 			if opts.Json {
 				ui.Json(response.GetData()[0])
 				return nil
@@ -58,13 +98,18 @@ func Command() *cobra.Command {
 			if len(args) != 1 {
 				return ui.Error(i18n.C.IndexErrorRequired)
 			}
-			response, err := session.Connect(config.Token()).GetIndexBackup(args[0])
+
+			client, err := validateIndex(args[0])
+			if err != nil {
+				return err
+			}
+
+			response, err := client.GetIndexBackup(args[0])
 			if err != nil {
 				return err
 			}
 
 			file, err := utils.ExtractFileBasename(response.GetData()[0].URL)
-
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/backup/backup.go
+++ b/pkg/cmd/backup/backup.go
@@ -2,8 +2,8 @@ package backup
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/i18n"
@@ -13,11 +13,13 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/utils"
 )
 
-func validateIndex(index string) (*sdk.Client, error) {
-	client := session.Connect(config.Token())
-	indicesResponse, err := client.GetIndices()
+// validateIndex checks whether index exists. If it does not but close matches
+// are found, an interactive select is presented so the user can pick one.
+// Returns the confirmed index name, or an error if the name is unrecognised.
+func validateIndex(index string) (string, error) {
+	indicesResponse, err := session.Connect(config.Token()).GetIndices()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Create a map of indices to compare against
@@ -28,20 +30,36 @@ func validateIndex(index string) (*sdk.Client, error) {
 		indexNames = append(indexNames, idx.Name)
 	}
 
-	// If the index is not present in the map, print output and suggest
-	// options for what the argument may have intended
-	if !available[index] {
-		var msg strings.Builder
-		fmt.Fprintf(&msg, "index '%s' does not exist", index)
-		if suggestions := utils.SuggestFor(index, indexNames); len(suggestions) > 0 {
-			msg.WriteString("\n\nDid you mean this?\n")
-			for _, s := range suggestions {
-				fmt.Fprintf(&msg, "\t%s\n", s)
-			}
-		}
-		return nil, fmt.Errorf("%s", msg.String())
+	if available[index] {
+		return index, nil
 	}
-	return client, nil
+
+	suggestions := utils.SuggestFor(index, indexNames)
+	if len(suggestions) == 0 {
+		return "", fmt.Errorf("index '%s' does not exist", index)
+	}
+
+	// If the index is not present in the map but close matches exist, present
+	// an interactive select so the user can choose the intended index
+	options := make([]huh.Option[string], len(suggestions))
+	for i, s := range suggestions {
+		options[i] = huh.NewOption(s, s)
+	}
+
+	var selected string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("index '%s' does not exist. Did you mean one of these?", index)).
+				Options(options...).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return "", fmt.Errorf("index '%s' does not exist", index)
+	}
+
+	return selected, nil
 }
 
 type UrlOptions struct {
@@ -67,14 +85,26 @@ func Command() *cobra.Command {
 				return ui.Error("index name is required")
 			}
 
-			client, err := validateIndex(args[0])
-			if err != nil {
-				return err
-			}
+			index := args[0]
+			client := session.Connect(config.Token())
+			response, err := client.GetIndexBackup(index)
 
-			response, err := client.GetIndexBackup(args[0])
+			// If GetIndexBackup fails due to a HTTP request error fallback
+			// and attempt to validate the index name argument provided if
+			// there was a typo/spelling error it will suggest similar names
 			if err != nil {
-				return err
+				if _, ok := err.(sdk.ReqError); ok {
+					corrected, validationErr := validateIndex(index)
+					if validationErr != nil {
+						return validationErr
+					}
+					response, err = client.GetIndexBackup(corrected)
+					if err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
 			}
 
 			if opts.Json {
@@ -99,14 +129,27 @@ func Command() *cobra.Command {
 				return ui.Error(i18n.C.IndexErrorRequired)
 			}
 
-			client, err := validateIndex(args[0])
-			if err != nil {
-				return err
-			}
+			index := args[0]
+			client := session.Connect(config.Token())
+			response, err := client.GetIndexBackup(index)
 
-			response, err := client.GetIndexBackup(args[0])
+			// If GetIndexBackup fails due to a HTTP request error fallback
+			// and attempt to validate the index name argument provided if
+			// there was a typo/spelling error it will suggest similar names
 			if err != nil {
-				return err
+				if _, ok := err.(sdk.ReqError); ok {
+					corrected, validationErr := validateIndex(index)
+					if validationErr != nil {
+						return validationErr
+					}
+					index = corrected
+					response, err = client.GetIndexBackup(index)
+					if err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
 			}
 
 			file, err := utils.ExtractFileBasename(response.GetData()[0].URL)
@@ -116,7 +159,7 @@ func Command() *cobra.Command {
 
 			date := utils.ParseDate(response.GetData()[0].DateAdded)
 
-			ui.Info(fmt.Sprintf(i18n.C.BackupDownloadInfo, args[0], date))
+			ui.Info(fmt.Sprintf(i18n.C.BackupDownloadInfo, index, date))
 			ui.Info(fmt.Sprintf(i18n.C.BackupDownloadProgress, file))
 			if err := ui.Download(response.GetData()[0].URL, file); err != nil {
 				return err

--- a/pkg/cmd/index/index.go
+++ b/pkg/cmd/index/index.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vulncheck-oss/cli/pkg/config"
@@ -11,7 +12,39 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/sdk"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
+	"github.com/vulncheck-oss/cli/pkg/utils"
 )
+
+func validateIndex(index string) (*sdk.Client, error) {
+	client := session.Connect(config.Token())
+	indicesResponse, err := client.GetIndices()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a map of indices to compare against
+	var indexNames []string
+	available := make(map[string]bool)
+	for _, idx := range indicesResponse.GetData() {
+		available[idx.Name] = true
+		indexNames = append(indexNames, idx.Name)
+	}
+
+	// If the index is not present in the map, print output and suggest
+	// options for what the argument may have intended
+	if !available[index] {
+		var msg strings.Builder
+		fmt.Fprintf(&msg, "index '%s' does not exist", index)
+		if suggestions := utils.SuggestFor(index, indexNames); len(suggestions) > 0 {
+			msg.WriteString("\n\nDid you mean this?\n")
+			for _, s := range suggestions {
+				fmt.Fprintf(&msg, "\t%s\n", s)
+			}
+		}
+		return nil, fmt.Errorf("%s", msg.String())
+	}
+	return client, nil
+}
 
 type Options struct {
 	Full bool
@@ -66,7 +99,11 @@ func Command() *cobra.Command {
 				}
 			}
 
-			response, err := session.Connect(config.Token()).GetIndex(args[0], queryParameters)
+			client, err := validateIndex(args[0])
+			if err != nil {
+				return err
+			}
+			response, err := client.GetIndex(args[0], queryParameters)
 			if err != nil {
 				return err
 			}
@@ -111,7 +148,11 @@ func Command() *cobra.Command {
 				}
 			}
 
-			response, err := session.Connect(config.Token()).GetIndex(args[0], queryParameters)
+			client, err := validateIndex(args[0])
+			if err != nil {
+				return err
+			}
+			response, err := client.GetIndex(args[0], queryParameters)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/index/index.go
+++ b/pkg/cmd/index/index.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/i18n"
@@ -15,11 +15,13 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/utils"
 )
 
-func validateIndex(index string) (*sdk.Client, error) {
-	client := session.Connect(config.Token())
-	indicesResponse, err := client.GetIndices()
+// validateIndex checks whether index exists. If it does not but close matches
+// are found, an interactive select is presented so the user can pick one.
+// Returns the confirmed index name, or an error if the name is unrecognised.
+func validateIndex(index string) (string, error) {
+	indicesResponse, err := session.Connect(config.Token()).GetIndices()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Create a map of indices to compare against
@@ -30,20 +32,36 @@ func validateIndex(index string) (*sdk.Client, error) {
 		indexNames = append(indexNames, idx.Name)
 	}
 
-	// If the index is not present in the map, print output and suggest
-	// options for what the argument may have intended
-	if !available[index] {
-		var msg strings.Builder
-		fmt.Fprintf(&msg, "index '%s' does not exist", index)
-		if suggestions := utils.SuggestFor(index, indexNames); len(suggestions) > 0 {
-			msg.WriteString("\n\nDid you mean this?\n")
-			for _, s := range suggestions {
-				fmt.Fprintf(&msg, "\t%s\n", s)
-			}
-		}
-		return nil, fmt.Errorf("%s", msg.String())
+	if available[index] {
+		return index, nil
 	}
-	return client, nil
+
+	suggestions := utils.SuggestFor(index, indexNames)
+	if len(suggestions) == 0 {
+		return "", fmt.Errorf("index '%s' does not exist", index)
+	}
+
+	// If the index is not present in the map but close matches exist, present
+	// an interactive select so the user can choose the intended index
+	options := make([]huh.Option[string], len(suggestions))
+	for i, s := range suggestions {
+		options[i] = huh.NewOption(s, s)
+	}
+
+	var selected string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("index '%s' does not exist. Did you mean one of these?", index)).
+				Options(options...).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return "", fmt.Errorf("index '%s' does not exist", index)
+	}
+
+	return selected, nil
 }
 
 type Options struct {
@@ -99,13 +117,26 @@ func Command() *cobra.Command {
 				}
 			}
 
-			client, err := validateIndex(args[0])
+			index := args[0]
+			client := session.Connect(config.Token())
+			response, err := client.GetIndex(index, queryParameters)
+
+			// If GetIndex fails due to a HTTP request error fallback
+			// and attempt to validate the index name argument provided if
+			// there was a typo/spelling error it will suggest similar names
 			if err != nil {
-				return err
-			}
-			response, err := client.GetIndex(args[0], queryParameters)
-			if err != nil {
-				return err
+				if _, ok := err.(sdk.ReqError); ok {
+					corrected, validationErr := validateIndex(index)
+					if validationErr != nil {
+						return validationErr
+					}
+					response, err = client.GetIndex(corrected, queryParameters)
+					if err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
 			}
 
 			var terminalOutput interface{}
@@ -148,13 +179,27 @@ func Command() *cobra.Command {
 				}
 			}
 
-			client, err := validateIndex(args[0])
+			index := args[0]
+			client := session.Connect(config.Token())
+			response, err := client.GetIndex(index, queryParameters)
+
+			// If GetIndex fails due to a HTTP request error fallback
+			// and attempt to validate the index name argument provided if
+			// there was a typo/spelling error it will suggest similar names
 			if err != nil {
-				return err
-			}
-			response, err := client.GetIndex(args[0], queryParameters)
-			if err != nil {
-				return err
+				if _, ok := err.(sdk.ReqError); ok {
+					corrected, validationErr := validateIndex(index)
+					if validationErr != nil {
+						return validationErr
+					}
+					index = corrected
+					response, err = client.GetIndex(index, queryParameters)
+					if err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
 			}
 
 			var viewportOutput interface{}
@@ -162,7 +207,7 @@ func Command() *cobra.Command {
 			if opts.Full {
 				viewportOutput = response
 			}
-			ui.Viewport(args[0], viewportOutput)
+			ui.Viewport(index, viewportOutput)
 
 			return nil
 		},

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -183,6 +183,51 @@ func FormatCVE(bareCve string) string {
 	return c
 }
 
+func SuggestFor(typed string, candidates []string) []string {
+	var suggestions []string
+	for _, c := range candidates {
+		dist := levenshtein(typed, c)
+		if dist <= 2 || strings.HasPrefix(strings.ToLower(c), strings.ToLower(typed)) {
+			suggestions = append(suggestions, c)
+		}
+	}
+	return suggestions
+}
+
+// levenshtein returns the edit distance between a and b (case-insensitive).
+// Edit distance is the minimum number of single-character insertions, deletions,
+// or substitutions needed to transform one string into the other.
+func levenshtein(a, b string) int {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+
+	// matrix[i][j] is the edit distance between the first i chars of a and
+	// the first j chars of b. Row 0 and column 0 represent the empty string:
+	// transforming "" into b[:j] costs j insertions; a[:i] into "" costs i deletions.
+	matrix := make([][]int, len(a)+1)
+	for i := range matrix {
+		matrix[i] = make([]int, len(b)+1)
+		matrix[i][0] = i
+	}
+	for j := range matrix[0] {
+		matrix[0][j] = j
+	}
+
+	for i := 1; i <= len(a); i++ {
+		for j := 1; j <= len(b); j++ {
+			if a[i-1] == b[j-1] {
+				// Characters match — carry the diagonal cost unchanged.
+				matrix[i][j] = matrix[i-1][j-1]
+			} else {
+				// Pick the cheapest of: delete from a, insert from b, or substitute.
+				matrix[i][j] = 1 + min(matrix[i-1][j], matrix[i][j-1], matrix[i-1][j-1])
+			}
+		}
+	}
+
+	return matrix[len(a)][len(b)]
+}
+
 func TrimVersionString(version ...string) string {
 	if len(version) > 0 && version[0] != "" {
 		return strings.TrimPrefix(version[0], "v")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -198,34 +198,34 @@ func SuggestFor(typed string, candidates []string) []string {
 // Edit distance is the minimum number of single-character insertions, deletions,
 // or substitutions needed to transform one string into the other.
 func levenshtein(a, b string) int {
-	a = strings.ToLower(a)
-	b = strings.ToLower(b)
+	ra := []rune(strings.ToLower(a))
+	rb := []rune(strings.ToLower(b))
 
-	// matrix[i][j] is the edit distance between the first i chars of a and
-	// the first j chars of b. Row 0 and column 0 represent the empty string:
-	// transforming "" into b[:j] costs j insertions; a[:i] into "" costs i deletions.
-	matrix := make([][]int, len(a)+1)
+	// matrix[i][j] is the edit distance between the first i runes of ra and
+	// the first j runes of rb. Row 0 and column 0 represent the empty string:
+	// transforming "" into rb[:j] costs j insertions; ra[:i] into "" costs i deletions.
+	matrix := make([][]int, len(ra)+1)
 	for i := range matrix {
-		matrix[i] = make([]int, len(b)+1)
+		matrix[i] = make([]int, len(rb)+1)
 		matrix[i][0] = i
 	}
 	for j := range matrix[0] {
 		matrix[0][j] = j
 	}
 
-	for i := 1; i <= len(a); i++ {
-		for j := 1; j <= len(b); j++ {
-			if a[i-1] == b[j-1] {
-				// Characters match — carry the diagonal cost unchanged.
+	for i := 1; i <= len(ra); i++ {
+		for j := 1; j <= len(rb); j++ {
+			if ra[i-1] == rb[j-1] {
+				// Runes match — carry the diagonal cost unchanged.
 				matrix[i][j] = matrix[i-1][j-1]
 			} else {
-				// Pick the cheapest of: delete from a, insert from b, or substitute.
+				// Pick the cheapest of: delete from ra, insert from rb, or substitute.
 				matrix[i][j] = 1 + min(matrix[i-1][j], matrix[i][j-1], matrix[i-1][j-1])
 			}
 		}
 	}
 
-	return matrix[len(a)][len(b)]
+	return matrix[len(ra)][len(rb)]
 }
 
 func TrimVersionString(version ...string) string {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -400,6 +400,12 @@ func TestSuggestFor(t *testing.T) {
 			candidates: []string{"pdns", "pdcp", "nvd"},
 			want:       []string{"pdns", "pdcp"},
 		},
+		{
+			name:       "utf-8 one rune typo",
+			typed:      "índex",
+			candidates: []string{"índices", "index"},
+			want:       []string{"index"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -415,6 +421,29 @@ func TestSuggestFor(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"abc", "ab", 1},
+		{"abc", "axc", 1},
+		{"", "abc", 3},
+		// Multi-byte UTF-8: each accented character is one rune, not 2+ bytes.
+		{"café", "cafe", 1},
+		{"naïve", "naive", 1},
+		{"résumé", "resume", 2},
+		{"日本語", "日本", 1},
+	}
+	for _, tt := range tests {
+		if got := levenshtein(tt.a, tt.b); got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
 	}
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -345,6 +345,79 @@ func TestFormatCVE(t *testing.T) {
 	})
 }
 
+func TestSuggestFor(t *testing.T) {
+	tests := []struct {
+		name       string
+		typed      string
+		candidates []string
+		want       []string
+	}{
+		{
+			name:       "exact match",
+			typed:      "pdns",
+			candidates: []string{"pdns", "nvd"},
+			want:       []string{"pdns"},
+		},
+		{
+			name:       "one character typo",
+			typed:      "pdnx",
+			candidates: []string{"pdns", "nvd"},
+			want:       []string{"pdns"},
+		},
+		{
+			name:       "two character typo",
+			typed:      "pdxx",
+			candidates: []string{"pdns", "nvd"},
+			want:       []string{"pdns"},
+		},
+		{
+			name:       "three character typo returns nothing",
+			typed:      "pxxx",
+			candidates: []string{"pdns", "nvd"},
+			want:       nil,
+		},
+		{
+			name:       "prefix match",
+			typed:      "initial-access",
+			candidates: []string{"initial-access-exploits", "nvd"},
+			want:       []string{"initial-access-exploits"},
+		},
+		{
+			name:       "case insensitive",
+			typed:      "PDNS",
+			candidates: []string{"pdns"},
+			want:       []string{"pdns"},
+		},
+		{
+			name:       "no close matches",
+			typed:      "zzz",
+			candidates: []string{"pdns", "nvd"},
+			want:       nil,
+		},
+		{
+			name:       "multiple suggestions",
+			typed:      "pdns",
+			candidates: []string{"pdns", "pdcp", "nvd"},
+			want:       []string{"pdns", "pdcp"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SuggestFor(tt.typed, tt.candidates)
+			if len(got) != len(tt.want) {
+				t.Errorf("SuggestFor() = %v, want %v", got, tt.want)
+				return
+			}
+			for i, s := range got {
+				if s != tt.want[i] {
+					t.Errorf("SuggestFor()[%d] = %v, want %v", i, s, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestGetPlatformAssetName(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This change implements validation and recommendations into the `backup` and `index` subcommands within the CLI tool. The background of this proposed change is a request made internally to have shell completion style feedback within the CLI tool for these subcommands.

The way in which this works is it implements a call to the index API endpoint to retrieve all current indices, validates the index name argument passed to either the `backup` or `index` subcommand and where the argument is invalid (no index name matches) uses Levenshtein distance to ascertain the best corrections to the mistype/spelling error if there are any.

Example of the change, when requesting a mistyped index name:
```shell
> vulncheck backup download gpc                                  
┃ index 'gpc' does not exist. Did you mean one of these?
┃ > gcp
┃   gem
┃   gen
┃   hp
┃   hpe
┃   nec
┃   npm
┃   ptc
┃   vlc

↑ up • ↓ down • / filter • enter submit
```

A matter of personal preference but I believe this is cleaner than the raw log message back that looks like:
```shell
✗ error: true, status code: 400, errors: [no backups found [index-backup: apachehadoop]]
```