### PR TITLE
Fix install arch options and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,11 @@ jobs:
           - windows-latest     # windows amd64
           - windows-11-arm     # windows arm64
           - macos-latest       # darwin arm64
-          - macos-13           # darwin amd64
+          # darwin amd64 intentionally not covered here. The Intel macOS runner
+          # (macos-13) is deprecation-era scarce — runs queue indefinitely —
+          # and the shipped darwin/amd64 binary is cross-compiled from Linux by
+          # GoReleaser, so a native Intel CI run would test a configuration
+          # that isn't actually how the release is produced.
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,14 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test -race ./...
+        # Go's race detector is not supported on windows/arm64.
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" = "windows-11-arm" ]; then
+            go test ./...
+          else
+            go test -race ./...
+          fi
 
       - name: Build
         run: go build -v ./cmd/vulncheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,14 @@ jobs:
           restore-keys: |
             go-${{ runner.os }}-
 
+      - name: Disable CGO on windows/arm64
+        # The windows-11-arm runner ships MinGW for x86_64 only, so any CGO build
+        # fails to assemble runtime/cgo's arm64 stubs. The released Windows ARM64
+        # binary is cross-compiled from Linux with CGO off — match that.
+        if: matrix.os == 'windows-11-arm'
+        shell: bash
+        run: echo "CGO_ENABLED=0" >> "$GITHUB_ENV"
+
       - name: Download dependencies
         run: go mod download
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os:
+          - ubuntu-latest      # linux amd64
+          - ubuntu-24.04-arm   # linux arm64
+          - windows-latest     # windows amd64
+          - windows-11-arm     # windows arm64
+          - macos-latest       # darwin arm64
+          - macos-13           # darwin amd64
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,17 @@
 $ErrorActionPreference = 'Stop'
 
-$arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "386" }
+# Read the OS architecture (not the process architecture — PROCESSOR_ARCHITEW6432
+# is set when a 32-bit PowerShell is running on a 64-bit OS).
+$procArch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+$arch = switch ($procArch.ToUpper()) {
+    "AMD64" { "amd64" }
+    "X86"   { "386" }
+    "ARM64" { "arm64" }
+    default {
+        Write-Error "Unsupported Windows architecture: $procArch (supported: AMD64, X86, ARM64)"
+        exit 1
+    }
+}
 $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/vulncheck-oss/cli/releases/latest"
 $asset = $latestRelease.assets | Where-Object { $_.name -like "*windows_$arch.zip" } | Select-Object -First 1
 

--- a/install.sh
+++ b/install.sh
@@ -59,12 +59,31 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     fi
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     OS="Linux"
-    ARCH="amd64"
+    case "$(uname -m)" in
+        x86_64|amd64)         ARCH="amd64" ;;
+        i386|i686)            ARCH="386" ;;
+        aarch64|arm64)        ARCH="arm64" ;;
+        armv6*|armv7*|armhf)  ARCH="armv6" ;;
+        *)
+            echo "Unsupported Linux architecture: $(uname -m)"
+            echo "Supported: x86_64, i386/i686, aarch64/arm64, armv6/armv7"
+            exit 1
+            ;;
+    esac
     DEFAULT_INSTALL_DIR="/usr/local/bin"
     LOCAL_INSTALL_DIR="$HOME/.local/bin"
 elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
     OS="Windows"
-    ARCH="amd64"
+    case "$(uname -m)" in
+        x86_64|amd64)   ARCH="amd64" ;;
+        i386|i686)      ARCH="386" ;;
+        aarch64|arm64)  ARCH="arm64" ;;
+        *)
+            echo "Unsupported Windows architecture: $(uname -m)"
+            echo "Supported: x86_64, i386/i686, aarch64/arm64"
+            exit 1
+            ;;
+    esac
     DEFAULT_INSTALL_DIR="/c/Windows/System32"
     LOCAL_INSTALL_DIR="$USERPROFILE/bin"
 else


### PR DESCRIPTION
- Better detections of architectures in the install scripts
- Extended test.yml's matrix from 3 → 6 entries, covering both architectures for each supported OS