### PR TITLE
Add offline vs online parity harness; fix sdk.GetCpe query accumulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@ completions: bin/vulncheck$(EXE)
 test:
 	go test ./...
 
+# Opt-in offline↔online parity suite. Needs VC_TOKEN and synced offline
+# indices; the tests skip themselves if either is missing. See pkg/parity.
+.PHONY: test-parity
+test-parity:
+	go test -tags=parity ./pkg/parity/...
+
 dbug:
 	@go get github.com/dbugapp/dbug-go
 

--- a/pkg/parity/README.md
+++ b/pkg/parity/README.md
@@ -1,0 +1,65 @@
+# pkg/parity
+
+Opt-in integration tests that diff the CLI's offline emulation of server-side
+matching against the live VulnCheck API. Offline mode is meant to emulate the
+API for air-gapped users, but nothing else in the tree asserts that `--offline`
+and online produce the same CVE set for the same input — past drift between
+them has only surfaced via customer reports. This suite closes that loop with a
+small, seeded fixture set so regressions get caught at PR time.
+
+## Running locally
+
+```sh
+# Auth (same env var the CLI itself reads via config.Token()).
+export VC_TOKEN=...
+
+# Sync every index the fixtures reference.
+vulncheck offline sync --add cpecve
+vulncheck offline sync --add alpine-purls
+vulncheck offline sync --add ubuntu-purls
+vulncheck offline sync --add debian-purls
+vulncheck offline sync --add npm
+vulncheck offline sync --add pypi
+vulncheck offline sync --add cargo
+vulncheck offline sync --add maven
+
+go test -tags=parity ./pkg/parity/...
+# or
+make test-parity
+```
+
+Missing token or missing indices → `t.Skip`. The suite never fails a default
+`go test ./...` run because the `parity` build tag hides it.
+
+## What the tests do
+
+- `TestPURLParity` — for each PURL in `testdata/purls.txt`, calls
+  `bill.GetBatchVulns` (online, `/v3/purls` batch) and `bill.GetOfflineVulns`
+  (offline sqlite), collapses each result to a CVE set, and asserts the sets
+  are equal.
+- `TestCPEParity` — for each CPE in `testdata/cpes.txt`, calls
+  `session.Client.GetCpe` (online, `/v3/cpe`) and `bill.GetOfflineCpeVulns`
+  (offline `cpecve` sqlite + client-side `cpeutils.Process`), and asserts the
+  CVE sets are equal.
+
+Failures print `only in online` / `only in offline` so the diff points at the
+exact drift, not just "sets differ".
+
+## Adding fixtures
+
+Every fixture ships with a comment explaining why it's there — either a
+regression seed tied to a shipped bug, or a coverage class (wildcards, version
+collisions, negative case). Keep the sets small; this is a parity gate, not a
+coverage test. When new drift is discovered, seed the case here so it can't
+come back silently.
+
+## What the tests deliberately do NOT do
+
+- Do not compare vulnerability metadata (CVSS, KEV, description). Those live
+  behind `MetaByCVE` / `GetIndexVulncheckNvd2` and are a CVE-id → row mapping
+  — extremely unlikely to drift.
+- Do not exercise the `scan` command end-to-end. That's a contract-test
+  surface. Running the underlying lookups directly makes the failure signal
+  precise.
+- Do not validate flags that only exist on one side (e.g. `--include-cpes` is
+  offline-only today; that asymmetry is a separate fix).

--- a/pkg/parity/parity_test.go
+++ b/pkg/parity/parity_test.go
@@ -1,0 +1,214 @@
+//go:build parity
+
+// Package parity contains an opt-in integration test suite that compares
+// the CLI's offline emulation of server-side matching against the live
+// VulnCheck API. Offline mode is meant to emulate the API for air-gapped
+// users, but nothing in the tree otherwise asserts that the two paths
+// actually agree on the same input — past drift has only surfaced via
+// customer reports (alpine PURL SBOMs returning zero vulns offline while
+// the same input returned many online; a linux_kernel CPE returning zero
+// in an offline SBOM scan while returning thousands via the online CPE
+// endpoint). Seeding those exact inputs here keeps them permanent
+// regression cases.
+//
+// Run with:
+//
+//	VC_TOKEN=... go test -tags=parity ./pkg/parity/...
+//
+// The build tag keeps this out of the default `go test ./...` run because it
+// needs a live token and locally synced indices; the test skips gracefully if
+// either precondition is missing.
+package parity
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/vulncheck-oss/cli/pkg/bill"
+	"github.com/vulncheck-oss/cli/pkg/cache"
+	"github.com/vulncheck-oss/cli/pkg/cmd/offline/packages"
+	"github.com/vulncheck-oss/cli/pkg/config"
+	"github.com/vulncheck-oss/cli/pkg/models"
+	"github.com/vulncheck-oss/cli/pkg/session"
+)
+
+// noopProgress is the iterator callback signature expected by the bill package.
+// The parity test doesn't render progress; a real scan does.
+func noopProgress(int, int) {}
+
+// preflight loads the shared preconditions (auth + synced indices) or skips
+// the test. Kept as a helper so both parity tests fail the same way.
+func preflight(t *testing.T) cache.InfoFile {
+	t.Helper()
+	if config.Token() == "" {
+		t.Skip("parity test requires VC_TOKEN in env (or a logged-in CLI config)")
+	}
+	indices, err := cache.Indices()
+	if err != nil {
+		t.Skipf("parity test requires synced offline indices: %v", err)
+	}
+	return indices
+}
+
+// loadFixture reads a fixture file, stripping blank lines and `#` comments so
+// PURL / CPE lists can be annotated inline.
+func loadFixture(t *testing.T, name string) []string {
+	t.Helper()
+	f, err := os.Open(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("open fixture %s: %v", name, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var out []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return out
+}
+
+// cveSet flattens a slice of vuln records into a sorted, deduplicated slice of
+// CVE ids. Parity is about which vulnerabilities each path finds, not how they
+// annotate them — CVSS / KEV / description differences are orthogonal.
+func cveSet(vulns []models.ScanResultVulnerabilities) []string {
+	seen := make(map[string]struct{}, len(vulns))
+	for _, v := range vulns {
+		if v.CVE == "" {
+			continue
+		}
+		seen[v.CVE] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for cve := range seen {
+		out = append(out, cve)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// diff returns the elements in a that are absent from b.
+func diff(a, b []string) []string {
+	bset := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		bset[x] = struct{}{}
+	}
+	var out []string
+	for _, x := range a {
+		if _, ok := bset[x]; !ok {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+// TestPURLParity walks every PURL in testdata/purls.txt through the online
+// batch endpoint and the offline sqlite lookup, and fails if the CVE sets
+// disagree. Regression seeds: alpine musl/busybox rows from the previously
+// reported "alpine offline returns zero vulns" drift.
+func TestPURLParity(t *testing.T) {
+	indices := preflight(t)
+	ctx := context.Background()
+	purls := loadFixture(t, "purls.txt")
+
+	for _, p := range purls {
+		t.Run(p, func(t *testing.T) {
+			instance, err := packageurl.FromString(p)
+			if err != nil {
+				t.Fatalf("parse purl: %v", err)
+			}
+			indexName := packages.IndexFromInstance(instance)
+			if indices.GetIndex(indexName) == nil {
+				t.Skipf("index %s not synced locally; run `vulncheck offline sync --add %s`", indexName, indexName)
+			}
+
+			detail := []models.PurlDetail{{Purl: p}}
+
+			onlineVulns, err := bill.GetBatchVulns(ctx, detail, noopProgress)
+			if err != nil {
+				t.Fatalf("online lookup: %v", err)
+			}
+			offlineVulns, err := bill.GetOfflineVulns(indices, detail, noopProgress, false)
+			if err != nil {
+				t.Fatalf("offline lookup: %v", err)
+			}
+
+			online, offline := cveSet(onlineVulns), cveSet(offlineVulns)
+			missingOffline := diff(online, offline)
+			extraOffline := diff(offline, online)
+			if len(missingOffline) > 0 || len(extraOffline) > 0 {
+				t.Errorf("PURL %s: online=%d offline=%d\n  only in online:  %v\n  only in offline: %v",
+					p, len(online), len(offline), missingOffline, extraOffline)
+			}
+		})
+	}
+}
+
+// TestCPEParity walks every CPE in testdata/cpes.txt through the online /v3/cpe
+// endpoint and the offline cpecve lookup, and fails if the CVE sets disagree.
+// Regression seed: linux_kernel CPE from the previously reported "SBOM CPE
+// scan returns zero while the online CPE endpoint returns thousands" drift.
+//
+// Note: `bill.GetOfflineCpeVulns` returns entries keyed by (cpe, cve) with
+// version/product metadata; we collapse to a CVE set to compare against the
+// online endpoint which returns []string of CVE ids directly.
+func TestCPEParity(t *testing.T) {
+	indices := preflight(t)
+	if indices.GetIndex("cpecve") == nil {
+		t.Skip("index cpecve not synced locally; run `vulncheck offline sync --add cpecve`")
+	}
+	ctx := context.Background()
+	client := session.ConnectWithContext(ctx, config.Token())
+	cpes := loadFixture(t, "cpes.txt")
+
+	for _, c := range cpes {
+		t.Run(c, func(t *testing.T) {
+			resp, err := client.GetCpe(c)
+			if err != nil {
+				t.Fatalf("online lookup: %v", err)
+			}
+			offlineVulns, err := bill.GetOfflineCpeVulns(indices, []string{c}, noopProgress, false)
+			if err != nil {
+				t.Fatalf("offline lookup: %v", err)
+			}
+
+			online := sortedUnique(resp.Data)
+			offline := cveSet(offlineVulns)
+			missingOffline := diff(online, offline)
+			extraOffline := diff(offline, online)
+			if len(missingOffline) > 0 || len(extraOffline) > 0 {
+				t.Errorf("CPE %s: online=%d offline=%d\n  only in online:  %v\n  only in offline: %v",
+					c, len(online), len(offline), missingOffline, extraOffline)
+			}
+		})
+	}
+}
+
+func sortedUnique(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	for _, x := range in {
+		if x == "" {
+			continue
+		}
+		seen[x] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for x := range seen {
+		out = append(out, x)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/parity/testdata/cpes.txt
+++ b/pkg/parity/testdata/cpes.txt
@@ -1,0 +1,24 @@
+# Fixture set for offline-vs-online CPE parity.
+# One CPE per line. Blank lines and `#` comments are ignored.
+#
+# Regression seed — the exact input from a previously reported drift where a
+# linux_kernel CPE returned zero in an offline SBOM scan while `vulncheck cpe`
+# returned thousands online (fixed in commit f7e0456). If this ever reports
+# "only in online" again, either the CycloneDX file-component extraction in
+# bill.LoadSBOM has regressed or the offline CPE lookup + client-side version
+# filter in cpeutils.Process has drifted from the server's matcher.
+cpe:2.3:o:*:linux_kernel:5.15.201:*:*:*:*:*:*:*
+
+# High-volume vendor to stress version-range logic in cpeutils.Process
+# (pkg/cpe/cpeutils/cpeutils.go:32) against the server matcher.
+cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*
+cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*
+cpe:2.3:a:nginx:nginx:1.18.0:*:*:*:*:*:*:*
+
+# Wildcards on vendor and product exercise the LIKE-clause branch in
+# db.CPESearch (pkg/db/cpe.go:31-58).
+cpe:2.3:a:*:log4j:2.14.1:*:*:*:*:*:*:*
+
+# Negative case — vendor/product that should not exist; both paths should
+# agree on the empty set.
+cpe:2.3:a:vendor-that-does-not-exist:product-x:1.0.0:*:*:*:*:*:*:*

--- a/pkg/parity/testdata/purls.txt
+++ b/pkg/parity/testdata/purls.txt
@@ -1,0 +1,27 @@
+# Fixture set for offline-vs-online PURL parity.
+# One PURL per line. Blank lines and `#` comments are ignored.
+#
+# Regression seeds — the exact inputs from a previously reported drift where
+# an alpine SBOM returned zero vulnerabilities offline while online returned
+# many (fixed in commit f7e0456). If either of these ever reports "only in
+# online" again, the OS-purls emulation has regressed.
+pkg:apk/alpine/musl@1.1.22-r2
+pkg:apk/alpine/busybox@1.30.1-r2
+pkg:apk/alpine/apk-tools@2.10.4-r1
+pkg:apk/alpine/zlib@1.2.11-r1
+
+# Other OS distros exercised by purlSearchOS (pkg/db/purl.go:101).
+# The API requires a distro qualifier — without it /v3/purls returns 500
+# "no distro qualifier found". Format: ?distro=<name>-<release>.
+pkg:deb/ubuntu/openssl@1.1.1f-1ubuntu2.16?distro=ubuntu-20.04
+pkg:deb/debian/curl@7.64.0-4+deb10u2?distro=debian-10
+
+# Language ecosystems exercised by purlSearchExact (pkg/db/purl.go:44).
+pkg:npm/lodash@4.17.15
+pkg:pypi/django@2.2.0
+pkg:cargo/openssl@0.10.29
+pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1
+
+# Version-prefix collision — regression for commit 9a2556c which anchored the
+# LIKE query on JSON quotes so "1.0.1" no longer matches "1.0.10".
+pkg:npm/minimist@1.2.0

--- a/pkg/sdk/cpe.go
+++ b/pkg/sdk/cpe.go
@@ -30,8 +30,13 @@ type CpeMeta struct {
 }
 
 // https://docs.vulncheck.com/api/cpe
+//
+// ResetQuery is mandatory here: c.Query appends via url.Values.Add, and
+// without a reset a reused Client would send ?cpe=<prev>&cpe=<current> on the
+// second call. The API keys off the first param and would silently return the
+// previous CPE's CVE set. Matches the pattern used by sdk.GetPurl.
 func (c *Client) GetCpe(cpe string) (responseJSON *CpeResponse, err error) {
-	resp, err := c.Query("cpe", cpe).Request("GET", "/v3/cpe")
+	resp, err := c.ResetQuery().Query("cpe", cpe).Request("GET", "/v3/cpe")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/cpe_test.go
+++ b/pkg/sdk/cpe_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +39,48 @@ func TestGetCpe(t *testing.T) {
 	t.Run("cpe response is parsed", func(t *testing.T) {
 		assert.Equal(t, "microsoft", cpeResp.Meta.CpeMeta.Vendor)
 	})
+}
+
+// TestGetCpeResetsQueryBetweenCalls guards against a copy-paste regression in
+// GetCpe: c.Query appends via url.Values.Add, so a reused Client that skipped
+// ResetQuery would send ?cpe=<prev>&cpe=<current> on the second call and the
+// API keyed off the first param — every call after the first silently
+// returned the previous CPE's CVE set. Surfaced by pkg/parity in the offline
+// vs online CPE comparison.
+func TestGetCpeResetsQueryBetweenCalls(t *testing.T) {
+	var received []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = append(received, r.URL.RawQuery)
+		_, _ = fmt.Fprintln(w, `{"_benchmark":0,"_meta":{},"data":[]}`)
+	}))
+	defer srv.Close()
+
+	client := Connect(srv.URL, "tok")
+
+	firstCpe := "cpe:2.3:a:vendor-a:product-a:1.0.0:*:*:*:*:*:*:*"
+	secondCpe := "cpe:2.3:a:vendor-b:product-b:2.0.0:*:*:*:*:*:*:*"
+
+	if _, err := client.GetCpe(firstCpe); err != nil {
+		t.Fatalf("first GetCpe: %v", err)
+	}
+	if _, err := client.GetCpe(secondCpe); err != nil {
+		t.Fatalf("second GetCpe: %v", err)
+	}
+
+	if len(received) != 2 {
+		t.Fatalf("expected 2 upstream requests, got %d", len(received))
+	}
+
+	// Each request must carry exactly one cpe param, and it must be the
+	// current call's value — not an accumulation from earlier calls.
+	for i, want := range []string{firstCpe, secondCpe} {
+		q, err := url.ParseQuery(received[i])
+		if err != nil {
+			t.Fatalf("parse request %d query: %v", i, err)
+		}
+		got := q["cpe"]
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("request %d: got cpe=%v, want [%q]", i, got, want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Add `pkg/parity`, an opt-in integration suite that runs the same PURLs and CPEs through both the offline sqlite path and the live API, and diffs the CVE sets. Build-tag-gated (`//go:build parity`) so it stays out of the default `go test ./...`; needs `VC_TOKEN` and locally synced indices, and skips gracefully when either is missing. Invoke with `make test-parity`.
- Fix `sdk.GetCpe`: `Client.Query` appends via `url.Values.Add`, so on a reused `Client` the second `GetCpe` call sent `?cpe=<prev>&cpe=<current>` and the API keyed off the first param — every call after the first silently returned the previous CPE's CVE set. Now matches the reset-query pattern already used by `GetPurl` / `GetPdns` / `GetRules` / `GetTags`, and covered by `TestGetCpeResetsQueryBetweenCalls`.

## Why

Offline mode is meant to emulate the API for users, but nothing in the tree today asserts that the two paths actually agree on the same input — past drift between them has surfaced only via customer reports. The parity harness closes that loop with a small, seeded fixture set so regressions get caught at PR time instead of in the field. The `sdk.GetCpe` bug is the first drift the harness found while it was being written.

## Test plan

- [x] `go test ./pkg/sdk/...` passes (includes `TestGetCpeResetsQueryBetweenCalls`)
- [x] `go build ./...` clean
- [x] `go test ./...` (no tag) does not pick up the parity package
- [x] With `VC_TOKEN` set and `cpecve` + at least one `*-purls` index synced: `make test-parity` runs the seeded cases and passes