### PR TITLE
Extract CPE/PURL from all CycloneDX objects that carry them

### DIFF
--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -185,14 +185,22 @@ func GetCPEDetail(sbm *sbom.SBOM, inputRefs []InputSbomRef) []string {
 }
 
 func GetPURLDetail(sbm *sbom.SBOM, inputRefs []InputSbomRef) []models.PurlDetail {
-	if sbm == nil {
-		return []models.PurlDetail{}
+	var purls []models.PurlDetail
+	seen := make(map[string]struct{})
+
+	add := func(purl models.PurlDetail) {
+		if purl.Purl == "" || strings.HasPrefix(purl.Purl, "pkg:github") {
+			return
+		}
+		if _, exists := seen[purl.Purl]; exists {
+			return
+		}
+		seen[purl.Purl] = struct{}{}
+		purls = append(purls, purl)
 	}
 
-	var purls []models.PurlDetail
-
-	for p := range sbm.Artifacts.Packages.Enumerate() {
-		if p.PURL != "" && !strings.HasPrefix(p.PURL, "pkg:github") {
+	if sbm != nil {
+		for p := range sbm.Artifacts.Packages.Enumerate() {
 			locations := make([]string, len(p.Locations.ToSlice()))
 			for i, l := range p.Locations.ToSlice() {
 				locations[i] = l.RealPath
@@ -212,10 +220,20 @@ func GetPURLDetail(sbm *sbom.SBOM, inputRefs []InputSbomRef) []models.PurlDetail
 				}
 			}
 
-			purls = append(purls, purlDetail)
-
+			add(purlDetail)
 		}
 	}
+
+	// CycloneDX components of type "file" (and others) carry PURLs that Syft
+	// does not surface as packages, so pull them straight from the parsed SBOM
+	// — mirrors what GetCPEDetail does for the CPE side.
+	for _, ref := range inputRefs {
+		add(models.PurlDetail{
+			Purl:    ref.PURL,
+			SbomRef: ref.SbomRef,
+		})
+	}
+
 	return purls
 }
 

--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -110,24 +110,35 @@ func LoadSBOM(inputFile string) (*sbom.SBOM, []InputSbomRef, error) {
 
 	var inputSbomRefs []InputSbomRef
 
-	// Extract bom-ref, purl and cpe from components. We read these straight from
-	// the raw JSON because Syft only surfaces packages: CycloneDX components of
-	// type "file" (and others) carry purls/cpes that never make it into
-	// sbm.Artifacts.Packages, so relying on the decoded SBOM alone drops them
+	// Extract bom-ref, purl and cpe from every CycloneDX object that can carry
+	// them. We read these straight from the raw JSON because Syft only surfaces
+	// what its catalogers recognise as packages: CycloneDX components of type
+	// "file" (and others), and metadata.component (the object the SBOM
+	// describes), carry purls/cpes that never make it into
+	// sbm.Artifacts.Packages, so relying on the decoded SBOM alone drops them.
+	appendRef := func(component map[string]interface{}) {
+		bomRef, _ := component["bom-ref"].(string)
+		purl, _ := component["purl"].(string)
+		cpe, _ := component["cpe"].(string)
+		if purl != "" || cpe != "" {
+			inputSbomRefs = append(inputSbomRefs, InputSbomRef{
+				SbomRef: bomRef,
+				PURL:    purl,
+				CPE:     cpe,
+			})
+		}
+	}
+
 	if components, ok := rawSBOM["components"].([]interface{}); ok {
 		for _, comp := range components {
 			if component, ok := comp.(map[string]interface{}); ok {
-				bomRef, _ := component["bom-ref"].(string)
-				purl, _ := component["purl"].(string)
-				cpe, _ := component["cpe"].(string)
-				if purl != "" || cpe != "" {
-					inputSbomRefs = append(inputSbomRefs, InputSbomRef{
-						SbomRef: bomRef,
-						PURL:    purl,
-						CPE:     cpe,
-					})
-				}
+				appendRef(component)
 			}
+		}
+	}
+	if metadata, ok := rawSBOM["metadata"].(map[string]interface{}); ok {
+		if component, ok := metadata["component"].(map[string]interface{}); ok {
+			appendRef(component)
 		}
 	}
 

--- a/pkg/bill/bill_test.go
+++ b/pkg/bill/bill_test.go
@@ -79,6 +79,35 @@ func TestLoadSBOM_CycloneDX17(t *testing.T) {
 	}
 }
 
+// TestLoadSBOM_MetadataComponent asserts that a purl/cpe declared on
+// metadata.component (the object the SBOM describes — often the top-level
+// scanned artifact, e.g. an OS image or firmware blob) is picked up. Syft
+// does not surface this as a package, so without the raw-JSON pass reading
+// metadata.component the top-level product would be silently unscanned.
+func TestLoadSBOM_MetadataComponent(t *testing.T) {
+	_, refs, err := LoadSBOM(filepath.Join("testdata", "cyclonedx-metadata-component.json"))
+	if err != nil {
+		t.Fatalf("LoadSBOM failed: %v", err)
+	}
+
+	var found bool
+	for _, r := range refs {
+		if r.SbomRef == "top-level-artifact" {
+			found = true
+			if r.PURL != "pkg:generic/example-os@1.0.0" {
+				t.Errorf("metadata.component PURL: got %q", r.PURL)
+			}
+			if r.CPE != "cpe:2.3:o:example:example-os:1.0.0:*:*:*:*:*:*:*" {
+				t.Errorf("metadata.component CPE: got %q", r.CPE)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("metadata.component ref not extracted; got refs=%+v", refs)
+	}
+}
+
 func TestGetPURLDetail(t *testing.T) {
 	mockSBOM := &sbom.SBOM{}
 

--- a/pkg/bill/bill_test.go
+++ b/pkg/bill/bill_test.go
@@ -92,6 +92,37 @@ func TestGetPURLDetail(t *testing.T) {
 	if len(nilPurls) != 0 {
 		t.Errorf("Expected 0 PURLs for nil SBOM, got %d", len(nilPurls))
 	}
+
+	// PURLs declared on CycloneDX "file" components are not surfaced by Syft
+	// as packages, so they reach us only through the raw inputRefs — the same
+	// class of gap the CPE side already handles.
+	refs := []InputSbomRef{
+		{SbomRef: "ref-1", PURL: "pkg:generic/qnx_software_development_platform@7.1"},
+		{SbomRef: "ref-2", PURL: "pkg:generic/qnx_software_development_platform@7.1"}, // duplicate
+		{SbomRef: "ref-3", PURL: ""},                                                  // empty
+		{SbomRef: "ref-4", PURL: "pkg:github/actions/checkout@v3"},                    // filtered
+		{SbomRef: "ref-5", PURL: "pkg:generic/other@1.0"},
+	}
+
+	got := GetPURLDetail(nil, refs)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 PURLs after dedupe + filters, got %d: %v", len(got), got)
+	}
+	wantByPurl := map[string]string{
+		"pkg:generic/qnx_software_development_platform@7.1": "ref-1",
+		"pkg:generic/other@1.0":                             "ref-5",
+	}
+	for _, p := range got {
+		wantRef, ok := wantByPurl[p.Purl]
+		if !ok {
+			t.Errorf("unexpected PURL %q in result", p.Purl)
+			continue
+		}
+		if p.SbomRef != wantRef {
+			t.Errorf("PURL %q: got SbomRef %q, want %q", p.Purl, p.SbomRef, wantRef)
+		}
+	}
 }
 
 func TestGetCPEDetail(t *testing.T) {

--- a/pkg/bill/testdata/cyclonedx-metadata-component.json
+++ b/pkg/bill/testdata/cyclonedx-metadata-component.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "serialNumber": "urn:uuid:00000000-0000-0000-0000-000000000000",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-01-01T00:00:00Z",
+    "component": {
+      "bom-ref": "top-level-artifact",
+      "type": "operating-system",
+      "name": "example-os",
+      "version": "1.0.0",
+      "purl": "pkg:generic/example-os@1.0.0",
+      "cpe": "cpe:2.3:o:example:example-os:1.0.0:*:*:*:*:*:*:*"
+    }
+  },
+  "components": []
+}


### PR DESCRIPTION
## Summary

- Rewrite `bill.GetPURLDetail` to mirror `bill.GetCPEDetail`: after iterating the packages Syft surfaces, walk the raw-JSON `inputRefs` and append any PURL that Syft did not already account for. Dedupe by PURL string; apply the same `pkg:github` filter. Previously `inputRefs` was used only to backfill `SbomRef` metadata onto packages Syft had found, so a CycloneDX component carrying only a `purl` (e.g. a `type: "file"` entry) was silently dropped.
- Extend the raw-JSON walk in `bill.LoadSBOM` to also read `metadata.component`. That object describes what the SBOM is about — often the top-level scanned artifact (an OS image, a firmware blob, an application) — and is the natural place to attach a `purl` or `cpe` identifying the product as a whole. Syft does not surface it as a package, and the raw walk only looked at the top-level `components[]` array, so any identifier attached there was ignored.
- Tests: extend `TestGetPURLDetail` with the same shape `TestGetCPEDetail` already uses (dedupe, empty, filter). Add `TestLoadSBOM_MetadataComponent` and a minimal fixture. Each new assertion was verified to fail against the pre-change code.

## Why

Offline mode is meant to emulate the API for air-gapped users, but a CycloneDX SBOM has several standard places where a `purl` or `cpe` can legitimately appear beyond the top-level `components[]`. When we miss any of them we silently under-scan — the customer sees fewer vulnerabilities than online mode would find. Two of those gaps came up in prior customer reports (both fixed for CPE, one still open for PURL, and neither covered `metadata.component`). This PR closes both concrete gaps and adds regression coverage so the same class of bug can't come back.

## Test plan

- [x] `go test ./pkg/bill/...` passes
- [x] `go build ./...` clean
- [x] Scanning a CycloneDX SBOM whose `metadata.component` declares a `cpe` or `purl` now reports vulnerabilities against it instead of ignoring it
- [x] Scanning a CycloneDX SBOM whose only PURL lives on a `type: "file"` (or otherwise non-package) component now surfaces that PURL's vulnerabilities