### PR TITLE
Add --enrich flag to expose syft's metadata enrichment during scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Generates an SBOM for `<path>`, extracts PURLs, then either calls the vulncheck 
 | `--offline-meta` | Populate metadata (CVSS, KEV, description) from `vulncheck-nvd2` in offline mode. |
 | `--warn-on-index` | Warn instead of failing when a required offline index isn't cached. |
 | `--disable-ui` | Alias for `--no-interactive` (kept for backwards compatibility). |
+| `--enrich` | Enrich the generated SBOM with metadata from `proxy.golang.org` / Maven Central / NPM / PyPI. Comma-separated scopes: `all`, `golang`, `java`, `javascript`, `python`; prefix with `-` to exclude (e.g. `all,-java`). Off by default; requires network — cannot be combined with `--offline` or `--sbom-input-file`. |
 
 The progress TUI is auto-suppressed whenever the renderer can't safely draw it (`--json`, `--no-interactive`, non-TTY, CI).
 

--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -73,13 +73,18 @@ func buildSBOMConfig(opts SBOMOptions) *syft.CreateSBOMConfig {
 
 	pkgCfg := pkgcataloging.DefaultConfig()
 
-	if enrichmentScope(opts.Enrich, "golang") {
+	// Aliases mirror syft's own task-name mapping (internal/task/package_tasks.go).
+	// Advertising only the publicised names in --help keeps parity with syft's help
+	// output, but users typing an alias syft accepts should still get the same
+	// behaviour they'd get from `syft --enrich <alias>`.
+	if enrichmentScope(opts.Enrich, "golang", "go") {
 		pkgCfg.Golang = pkgCfg.Golang.
 			WithSearchLocalModCacheLicenses(true).
 			WithSearchLocalVendorLicenses(true).
-			WithSearchRemoteLicenses(true)
+			WithSearchRemoteLicenses(true).
+			WithUsePackagesLib(true)
 	}
-	if enrichmentScope(opts.Enrich, "javascript") {
+	if enrichmentScope(opts.Enrich, "javascript", "node", "npm") {
 		pkgCfg.JavaScript = pkgCfg.JavaScript.WithSearchRemoteLicenses(true)
 	}
 	if enrichmentScope(opts.Enrich, "python") {
@@ -87,7 +92,7 @@ func buildSBOMConfig(opts SBOMOptions) *syft.CreateSBOMConfig {
 			WithSearchRemoteLicenses(true).
 			WithGuessUnpinnedRequirements(true)
 	}
-	if enrichmentScope(opts.Enrich, "java") {
+	if enrichmentScope(opts.Enrich, "java", "maven") {
 		pkgCfg.JavaArchive = pkgCfg.JavaArchive.
 			WithUseMavenLocalRepository(true).
 			WithUseNetwork(true)
@@ -96,11 +101,12 @@ func buildSBOMConfig(opts SBOMOptions) *syft.CreateSBOMConfig {
 	return syft.DefaultCreateSBOMConfig().WithPackagesConfig(pkgCfg)
 }
 
-// enrichmentScope reports whether enrichment should be enabled for the given
-// scope under the user's directives, using the same precedence syft's CLI
-// uses: an explicit `+scope` / bare `scope` / `-scope` wins over the `all` /
-// `none` fallback.
-func enrichmentScope(directives []string, scope string) bool {
+// enrichmentScope reports whether enrichment should be enabled for a language
+// under the user's directives. Multiple aliases can be passed for languages
+// syft's CLI accepts under more than one name (e.g. golang/go, javascript/node/npm,
+// java/maven); an explicit `+alias` / bare `alias` / `-alias` on any of them
+// wins over the `all` / `none` fallback, matching syft's own precedence.
+func enrichmentScope(directives []string, aliases ...string) bool {
 	lookup := func(name string) (found, enable bool) {
 		for _, d := range directives {
 			d = strings.TrimPrefix(d, "+")
@@ -114,8 +120,10 @@ func enrichmentScope(directives []string, scope string) bool {
 		}
 		return false, false
 	}
-	if found, en := lookup(scope); found {
-		return en
+	for _, alias := range aliases {
+		if found, en := lookup(alias); found {
+			return en
+		}
 	}
 	if _, disableAll := lookup("none"); disableAll {
 		return false

--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/format/cyclonedxjson"
 	"github.com/anchore/syft/syft/sbom"
@@ -32,18 +33,97 @@ type InputSbomRef struct {
 	CPE     string
 }
 
-func GetSBOM(dir string) (*sbom.SBOM, error) {
+// SBOMOptions carries knobs for GetSBOM. Kept as a struct so future toggles
+// can be added without churning every caller.
+type SBOMOptions struct {
+	// Enrich is a passthrough of syft's `--enrich` scope list. Empty means
+	// enrichment is disabled and syft runs with its default (offline-safe)
+	// behaviour. Non-empty entries opt in to network-backed metadata lookups
+	// (proxy.golang.org, Maven Central, NPM registry, PyPI) — see
+	// buildEnrichConfig for which fields each scope flips.
+	Enrich []string
+}
+
+func GetSBOM(dir string, opts SBOMOptions) (*sbom.SBOM, error) {
 	src, err := syft.GetSource(context.Background(), dir, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	sbm, err := syft.CreateSBOM(context.Background(), src, nil)
+	sbm, err := syft.CreateSBOM(context.Background(), src, buildSBOMConfig(opts))
 	if err != nil {
 		return nil, err
 	}
 
 	return sbm, nil
+}
+
+// buildSBOMConfig returns nil when no options need setting, preserving syft's
+// default behaviour end-to-end. When Enrich is populated it starts from syft's
+// defaults and flips the same per-language fields that syft's own CLI flips
+// for `--enrich <scope>` — the scope mapping lives in syft's internal options
+// package (cmd/syft/internal/options/catalog.go) and cannot be imported, so we
+// mirror it here. Scopes match syft's publicised list: all, golang, java,
+// javascript, python. The `+scope` / `-scope` / `all` / `none` precedence
+// rules are handled by enrichmentScope.
+func buildSBOMConfig(opts SBOMOptions) *syft.CreateSBOMConfig {
+	if len(opts.Enrich) == 0 {
+		return nil
+	}
+
+	pkgCfg := pkgcataloging.DefaultConfig()
+
+	if enrichmentScope(opts.Enrich, "golang") {
+		pkgCfg.Golang = pkgCfg.Golang.
+			WithSearchLocalModCacheLicenses(true).
+			WithSearchLocalVendorLicenses(true).
+			WithSearchRemoteLicenses(true)
+	}
+	if enrichmentScope(opts.Enrich, "javascript") {
+		pkgCfg.JavaScript = pkgCfg.JavaScript.WithSearchRemoteLicenses(true)
+	}
+	if enrichmentScope(opts.Enrich, "python") {
+		pkgCfg.Python = pkgCfg.Python.
+			WithSearchRemoteLicenses(true).
+			WithGuessUnpinnedRequirements(true)
+	}
+	if enrichmentScope(opts.Enrich, "java") {
+		pkgCfg.JavaArchive = pkgCfg.JavaArchive.
+			WithUseMavenLocalRepository(true).
+			WithUseNetwork(true)
+	}
+
+	return syft.DefaultCreateSBOMConfig().WithPackagesConfig(pkgCfg)
+}
+
+// enrichmentScope reports whether enrichment should be enabled for the given
+// scope under the user's directives, using the same precedence syft's CLI
+// uses: an explicit `+scope` / bare `scope` / `-scope` wins over the `all` /
+// `none` fallback.
+func enrichmentScope(directives []string, scope string) bool {
+	lookup := func(name string) (found, enable bool) {
+		for _, d := range directives {
+			d = strings.TrimPrefix(d, "+")
+			neg := strings.HasPrefix(d, "-")
+			if neg {
+				d = d[1:]
+			}
+			if d == name {
+				return true, !neg
+			}
+		}
+		return false, false
+	}
+	if found, en := lookup(scope); found {
+		return en
+	}
+	if _, disableAll := lookup("none"); disableAll {
+		return false
+	}
+	if _, enableAll := lookup("all"); enableAll {
+		return true
+	}
+	return false
 }
 
 func SaveSBOM(sbm *sbom.SBOM, file string) error {

--- a/pkg/bill/bill_test.go
+++ b/pkg/bill/bill_test.go
@@ -121,6 +121,115 @@ func TestGetCPEDetail(t *testing.T) {
 	}
 }
 
+// TestBuildSBOMConfig documents the mapping between our --enrich directive
+// slice and the pkgcataloging.Config fields we hand to syft. Locks in the
+// expected per-scope behaviour so a future refactor can't quietly stop
+// flipping (or start over-flipping) fields.
+func TestBuildSBOMConfig(t *testing.T) {
+	t.Run("empty Enrich returns nil (preserves syft defaults)", func(t *testing.T) {
+		if cfg := buildSBOMConfig(SBOMOptions{}); cfg != nil {
+			t.Fatalf("expected nil config for empty Enrich, got %+v", cfg)
+		}
+	})
+
+	t.Run("Enrich=all flips every scope", func(t *testing.T) {
+		cfg := buildSBOMConfig(SBOMOptions{Enrich: []string{"all"}})
+		if cfg == nil {
+			t.Fatal("expected non-nil config")
+		}
+		if !cfg.Packages.Golang.SearchRemoteLicenses {
+			t.Error("golang.SearchRemoteLicenses not enabled under all")
+		}
+		if !cfg.Packages.Golang.SearchLocalModCacheLicenses {
+			t.Error("golang.SearchLocalModCacheLicenses not enabled under all")
+		}
+		if !cfg.Packages.Golang.SearchLocalVendorLicenses {
+			t.Error("golang.SearchLocalVendorLicenses not enabled under all")
+		}
+		if !cfg.Packages.JavaScript.SearchRemoteLicenses {
+			t.Error("javascript.SearchRemoteLicenses not enabled under all")
+		}
+		if !cfg.Packages.Python.SearchRemoteLicenses {
+			t.Error("python.SearchRemoteLicenses not enabled under all")
+		}
+		if !cfg.Packages.Python.GuessUnpinnedRequirements {
+			t.Error("python.GuessUnpinnedRequirements not enabled under all")
+		}
+		if !cfg.Packages.JavaArchive.UseNetwork {
+			t.Error("java.UseNetwork not enabled under all")
+		}
+		if !cfg.Packages.JavaArchive.UseMavenLocalRepository {
+			t.Error("java.UseMavenLocalRepository not enabled under all")
+		}
+	})
+
+	t.Run("single scope only flips that scope", func(t *testing.T) {
+		cfg := buildSBOMConfig(SBOMOptions{Enrich: []string{"golang"}})
+		if !cfg.Packages.Golang.SearchRemoteLicenses {
+			t.Error("golang enrichment not enabled")
+		}
+		if cfg.Packages.JavaScript.SearchRemoteLicenses {
+			t.Error("javascript enrichment leaked in")
+		}
+		if cfg.Packages.Python.SearchRemoteLicenses {
+			t.Error("python enrichment leaked in")
+		}
+		if cfg.Packages.JavaArchive.UseNetwork {
+			t.Error("java enrichment leaked in")
+		}
+	})
+
+	t.Run("all with per-scope negation excludes only that scope", func(t *testing.T) {
+		cfg := buildSBOMConfig(SBOMOptions{Enrich: []string{"all", "-java"}})
+		if !cfg.Packages.Golang.SearchRemoteLicenses {
+			t.Error("golang should still be enabled")
+		}
+		if cfg.Packages.JavaArchive.UseNetwork {
+			t.Error("java should be excluded by -java")
+		}
+	})
+
+	t.Run("none disables everything", func(t *testing.T) {
+		cfg := buildSBOMConfig(SBOMOptions{Enrich: []string{"none"}})
+		if cfg == nil {
+			t.Fatal("expected non-nil config even when none directive is present")
+		}
+		if cfg.Packages.Golang.SearchRemoteLicenses {
+			t.Error("golang should be disabled under none")
+		}
+		if cfg.Packages.JavaScript.SearchRemoteLicenses {
+			t.Error("javascript should be disabled under none")
+		}
+	})
+}
+
+func TestEnrichmentScope(t *testing.T) {
+	cases := []struct {
+		name       string
+		directives []string
+		scope      string
+		want       bool
+	}{
+		{"empty directives", nil, "golang", false},
+		{"bare scope match", []string{"golang"}, "golang", true},
+		{"plus scope match", []string{"+golang"}, "golang", true},
+		{"negated scope match", []string{"-golang"}, "golang", false},
+		{"all enables scope", []string{"all"}, "golang", true},
+		{"none disables scope", []string{"none"}, "golang", false},
+		{"all beats none absent", []string{"all"}, "python", true},
+		{"explicit negation beats all", []string{"all", "-python"}, "python", false},
+		{"explicit include beats none", []string{"none", "+python"}, "python", true},
+		{"unrelated scope stays off", []string{"golang"}, "python", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := enrichmentScope(tc.directives, tc.scope); got != tc.want {
+				t.Errorf("enrichmentScope(%v, %q) = %v, want %v", tc.directives, tc.scope, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFormatSingleDecimal(t *testing.T) {
 	testCases := []struct {
 		input    float32

--- a/pkg/bill/bill_test.go
+++ b/pkg/bill/bill_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/vulncheck-oss/cli/pkg/cache"
 	"github.com/vulncheck-oss/cli/pkg/models"
@@ -199,6 +200,35 @@ func TestBuildSBOMConfig(t *testing.T) {
 		}
 		if cfg.Packages.JavaScript.SearchRemoteLicenses {
 			t.Error("javascript should be disabled under none")
+		}
+	})
+
+	// Syft accepts several scope aliases per language (internal/task/package_tasks.go):
+	// go/golang, javascript/node/npm, java/maven. Users typing any of them should
+	// get the same behaviour as with the publicised name.
+	aliases := []struct {
+		name  string
+		alias string
+		check func(cfg *syft.CreateSBOMConfig) bool
+	}{
+		{"go alias enables golang", "go", func(c *syft.CreateSBOMConfig) bool { return c.Packages.Golang.SearchRemoteLicenses }},
+		{"node alias enables javascript", "node", func(c *syft.CreateSBOMConfig) bool { return c.Packages.JavaScript.SearchRemoteLicenses }},
+		{"npm alias enables javascript", "npm", func(c *syft.CreateSBOMConfig) bool { return c.Packages.JavaScript.SearchRemoteLicenses }},
+		{"maven alias enables java", "maven", func(c *syft.CreateSBOMConfig) bool { return c.Packages.JavaArchive.UseNetwork }},
+	}
+	for _, a := range aliases {
+		t.Run(a.name, func(t *testing.T) {
+			cfg := buildSBOMConfig(SBOMOptions{Enrich: []string{a.alias}})
+			if cfg == nil || !a.check(cfg) {
+				t.Errorf("--enrich %s did not enable the language it aliases", a.alias)
+			}
+		})
+	}
+
+	t.Run("golang enrichment sets UsePackagesLib", func(t *testing.T) {
+		cfg := buildSBOMConfig(SBOMOptions{Enrich: []string{"golang"}})
+		if !cfg.Packages.Golang.UsePackagesLib {
+			t.Error("golang enrichment did not set UsePackagesLib (matches syft's own flip)")
 		}
 	})
 }

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -69,6 +69,14 @@ func Command() *cobra.Command {
 				return ui.Error("--enrich has no effect when reading a pre-built SBOM via --sbom-input-file")
 			}
 
+			// Enrichment fetches metadata from proxy.golang.org, Maven Central,
+			// NPM and PyPI — none of which are reachable in offline mode. Fail
+			// loudly rather than silently produce an SBOM missing the metadata
+			// the user opted in for.
+			if opts.Offline && len(opts.Enrich) > 0 {
+				return ui.Error("--enrich requires network access and cannot be combined with --offline")
+			}
+
 			var sbm *sbom.SBOM
 			var inputRefs []bill.InputSbomRef
 			var purls []models.PurlDetail

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -41,6 +41,7 @@ type Options struct {
 	OfflineMeta bool
 	DisableUI   bool
 	WarnOnIndex bool
+	Enrich      []string
 }
 
 func Command() *cobra.Command {
@@ -58,6 +59,14 @@ func Command() *cobra.Command {
 
 			if opts.SbomInput == "" && len(args) < 1 {
 				return ui.Error(i18n.C.ScanErrorDirectoryRequired)
+			}
+
+			// Enrichment only kicks in during SBOM generation. Reading a
+			// pre-built SBOM via --sbom-input-file skips generation, so
+			// --enrich would silently do nothing — hard-fail instead of
+			// pretending the flag took effect.
+			if opts.SbomInput != "" && len(opts.Enrich) > 0 {
+				return ui.Error("--enrich has no effect when reading a pre-built SBOM via --sbom-input-file")
 			}
 
 			var sbm *sbom.SBOM
@@ -98,7 +107,7 @@ func Command() *cobra.Command {
 					Title: i18n.C.ScanSbomStart,
 					Task: func(t *taskin.Task) error {
 						var err error
-						sbm, err = bill.GetSBOM(args[0])
+						sbm, err = bill.GetSBOM(args[0], bill.SBOMOptions{Enrich: opts.Enrich})
 						if err != nil {
 							return err
 						}
@@ -354,6 +363,7 @@ func Command() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.OfflineMeta, "offline-meta", false, "Use with offline mode to populate CVE metadata - requires the vulncheck-nvd2 index to be cached")
 	cmd.Flags().BoolVar(&opts.WarnOnIndex, "warn-on-index", false, "When an index is not present locally, show a warning instead of shutting down")
 	cmd.Flags().BoolVar(&opts.DisableUI, "disable-ui", false, "Disable interactive UI elements (progress bars, spinners)")
+	cmd.Flags().StringSliceVar(&opts.Enrich, "enrich", nil, i18n.C.FlagEnrich)
 
 	return cmd
 }

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -32,6 +32,7 @@ type Copy struct {
 	FlagSpecifySbomInput string
 	FlagSpecifySbomOnly  string
 	FlagIncludeCpes      string
+	FlagEnrich           string
 	SavingResultsStart   string
 	SavingResultsEnd     string
 
@@ -194,6 +195,7 @@ var En = Copy{
 	FlagSpecifySbomInput: "Specify an existing SBOM file to scan instead of creating one from a folder",
 	FlagSpecifySbomOnly:  "Do not run a scan and only create a SBOM file",
 	FlagIncludeCpes:      "Include and Scan CPEs",
+	FlagEnrich:           "Enrich the generated SBOM with additional metadata from local and online sources (e.g. proxy.golang.org, Maven Central, NPM, PyPI). Comma-separated scopes; supported values: all, golang, java, javascript, python. Prefix with '-' to exclude (e.g. all,-java). Off by default; enabling adds runtime cost and requires network access. Has no effect with --sbom-input-file.",
 	SavingResultsStart:   "Saving Results to %s",
 	SavingResultsEnd:     "Results saved to %s",
 

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -195,7 +195,7 @@ var En = Copy{
 	FlagSpecifySbomInput: "Specify an existing SBOM file to scan instead of creating one from a folder",
 	FlagSpecifySbomOnly:  "Do not run a scan and only create a SBOM file",
 	FlagIncludeCpes:      "Include and Scan CPEs",
-	FlagEnrich:           "Enrich the generated SBOM with additional metadata from local and online sources (e.g. proxy.golang.org, Maven Central, NPM, PyPI). Comma-separated scopes; supported values: all, golang, java, javascript, python. Prefix with '-' to exclude (e.g. all,-java). Off by default; enabling adds runtime cost and requires network access. Has no effect with --sbom-input-file.",
+	FlagEnrich:           "Enrich the generated SBOM with additional metadata from local and online sources (e.g. proxy.golang.org, Maven Central, NPM, PyPI). Comma-separated scopes; supported values: all, golang, java, javascript, python. Prefix with '-' to exclude (e.g. all,-java). Off by default; enabling adds runtime cost and requires network access. Cannot be combined with --offline or --sbom-input-file.",
 	SavingResultsStart:   "Saving Results to %s",
 	SavingResultsEnd:     "Results saved to %s",
 


### PR DESCRIPTION
## Summary

- New `--enrich` flag on `vulncheck scan` that mirrors syft's own `--enrich` directive: a comma-separated scope list drawn from `{all, golang, java, javascript, python}` with syft's `+scope` / `-scope` prefix conventions. Off by default, so existing behaviour is preserved and no unexpected network calls happen.
- When set, syft's per-language cataloger configs get the same fields flipped that syft's own CLI flips for `--enrich`, letting syft fetch license and package metadata from `proxy.golang.org`, Maven Central, NPM, and PyPI.
- Hard-fail when `--enrich` is combined with `--sbom-input-file` (enrichment only applies during SBOM generation) or `--offline` (enrichment requires network access). Matches the "explicit error over silent no-op" pattern used elsewhere in scan.
- Unit tests cover the config-building (`empty → nil`, `all` flips every scope, single scopes stay isolated, `all,-scope` excludes only that scope, `none` disables everything) and the scope-precedence rules (`+scope` / `-scope` beat `all` / `none`).
- Flag help text and the scan flag table in `README.md` updated.

## Why

Customers asked for a way to include richer package metadata (licenses in particular) in generated SBOMs. Syft already supports this via its `--enrich` directive; the CLI just wasn't exposing it. Adding a flag rather than always-on keeps the default offline-safe and avoids the extra runtime cost when the extra metadata isn't needed.

## Test plan

- [x] `go test ./pkg/bill/...` passes (includes `TestBuildSBOMConfig`, `TestEnrichmentScope`)
- [x] `go build ./...` clean
- [x] `vulncheck scan <dir> --sbom-only --enrich all --sbom-output-file out.json` on a Go module populates `.components[].licenses` where a plain run does not
- [x] `vulncheck scan -i <sbom> --enrich all` prints `--enrich has no effect when reading a pre-built SBOM via --sbom-input-file` and exits non-zero
- [x] `vulncheck scan <dir> --enrich all --offline` prints `--enrich requires network access and cannot be combined with --offline` and exits non-zero
- [x] `vulncheck scan --help` shows the new flag with the mutual-exclusion notes