### PR TITLE
fix: don't block on TTY stdin in batch subcommands

### DIFF
--- a/internal/batch/batch.go
+++ b/internal/batch/batch.go
@@ -27,11 +27,13 @@ type Result struct {
 //
 //	args      - positional CLI arguments (caller passes cobra's args slice)
 //	fromFile  - value of --from-file (empty = unset)
-//	stdin     - reader to use for stdin fallback; nil defaults to os.Stdin
+//	stdin     - reader to use for stdin fallback; nil skips stdin entirely
 //
-// Precedence: --from-file wins, then positional args, then stdin if it is
-// not a terminal. Empty/whitespace lines and leading '#' comment lines
-// are skipped. Returns an empty slice if no source provided any input.
+// Precedence: --from-file wins, then positional args, then stdin. Callers
+// wiring an interactive TTY must pass nil to opt out — otherwise a
+// blocking Read on the terminal will hang the command and swallow
+// Ctrl+C. Empty/whitespace lines and leading '#' comment lines are
+// skipped. Returns an empty slice if no source provided any input.
 func CollectInputs(args []string, fromFile string, stdin io.Reader) ([]string, error) {
 	if fromFile != "" {
 		f, err := os.Open(fromFile)
@@ -45,11 +47,8 @@ func CollectInputs(args []string, fromFile string, stdin io.Reader) ([]string, e
 		return args, nil
 	}
 	if stdin == nil {
-		stdin = os.Stdin
+		return nil, nil
 	}
-	// Only consume stdin when it is being piped to us — interactive shells
-	// would block forever. Caller is expected to have checked TTY via
-	// output.IsTTY(os.Stdin) when wiring this.
 	return readLines(stdin), nil
 }
 

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -66,3 +66,16 @@ func TestCollectInputsMissingFile(t *testing.T) {
 		t.Fatal("expected error for missing file")
 	}
 }
+
+// A nil stdin means "no stdin available" — CollectInputs must NOT fall
+// back to os.Stdin, which would block on a TTY and hang subcommands
+// like `vulncheck pdns` / `vulncheck tag` (issue #3194).
+func TestCollectInputsNilStdinReturnsEmpty(t *testing.T) {
+	got, err := CollectInputs(nil, "", nil)
+	if err != nil {
+		t.Fatalf("CollectInputs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %v", got)
+	}
+}

--- a/internal/batch/batch_test.go
+++ b/internal/batch/batch_test.go
@@ -69,7 +69,7 @@ func TestCollectInputsMissingFile(t *testing.T) {
 
 // A nil stdin means "no stdin available" — CollectInputs must NOT fall
 // back to os.Stdin, which would block on a TTY and hang subcommands
-// like `vulncheck pdns` / `vulncheck tag` (issue #3194).
+// like `vulncheck pdns` / `vulncheck tag`.
 func TestCollectInputsNilStdinReturnsEmpty(t *testing.T) {
 	got, err := CollectInputs(nil, "", nil)
 	if err != nil {


### PR DESCRIPTION
CollectInputs overrode a nil stdin argument with os.Stdin, defeating the stdinIfPiped() guard in pdns/tag/purl/cpe. When a user ran `vulncheck pdns` or `vulncheck tag` interactively with no args, bufio.Scanner.Scan() blocked on a terminal read that Ctrl+C could not interrupt (the SIGINT handler cancels ctx but can't unblock a syscall read).

Treat nil stdin as "no stdin available" and return empty, matching the documented intent in `pkg/cmd/purl/stdin.go`.