### PR TITLE
fix: allow backup download of non-zip index backups

### DIFF
--- a/pkg/cmd/backup/backup.go
+++ b/pkg/cmd/backup/backup.go
@@ -145,7 +145,7 @@ func Command() *cobra.Command {
 				}
 			}
 
-			file, err := utils.ExtractFileBasename(response.GetData()[0].URL)
+			file, err := utils.BackupFilename(response.GetData()[0].URL)
 			if err != nil {
 				return err
 			}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -50,6 +50,30 @@ func ExtractFileBasename(urlStr string) (string, error) {
 	return filepath.Base(name), nil
 }
 
+// BackupFilename derives the local filename to save an index backup under.
+// Unlike ExtractFile it makes no assumption about the archive format: most
+// indices ship a zip, but target-intel ships a bare Avro container file.
+func BackupFilename(urlStr string) (string, error) {
+	parsedUrl, err := url.Parse(urlStr)
+	if err != nil {
+		return "", err
+	}
+
+	// filepath.Base trims a trailing separator, so "/latest/" would otherwise
+	// resolve to the directory name "latest" rather than being rejected.
+	path := strings.TrimPrefix(parsedUrl.Path, "/")
+	if path == "" || strings.HasSuffix(path, "/") {
+		return "", fmt.Errorf("could not determine a filename from backup URL")
+	}
+
+	name := filepath.Base(path)
+	if name == "." || name == ".." || name == string(os.PathSeparator) {
+		return "", fmt.Errorf("could not determine a filename from backup URL")
+	}
+
+	return name, nil
+}
+
 // ParseDate parses a date string in RFC3339 format and returns a formatted string.
 func ParseDate(date string) string {
 	dateAdded, err := time.Parse(time.RFC3339, date)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -183,6 +183,80 @@ func TestExtractFileBasename(t *testing.T) {
 	}
 }
 
+func TestBackupFilename(t *testing.T) {
+	tests := []struct {
+		name    string
+		urlStr  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Zip backup",
+			urlStr:  "https://example.com/latest/exploits-1786528609040972582.zip",
+			want:    "exploits-1786528609040972582.zip",
+			wantErr: false,
+		},
+		{
+			// target-intel ships Avro rather than zip; this is the case that
+			// ExtractFile rejects outright.
+			name:    "Avro backup",
+			urlStr:  "https://example.com/latest/target-intel-1786521601737157533.avro",
+			want:    "target-intel-1786521601737157533.avro",
+			wantErr: false,
+		},
+		{
+			// Backup URLs are presigned and always carry a query string.
+			name:    "URL with query parameters",
+			urlStr:  "https://example.com/latest/target-intel-1786521601737157533.avro?X-Amz-Expires=900&X-Amz-Signature=abc",
+			want:    "target-intel-1786521601737157533.avro",
+			wantErr: false,
+		},
+		{
+			name:    "No extension",
+			urlStr:  "https://example.com/latest/target-intel",
+			want:    "target-intel",
+			wantErr: false,
+		},
+		{
+			name:    "Invalid URL",
+			urlStr:  "://invalid-url",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "No path",
+			urlStr:  "https://example.com",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Directory path",
+			urlStr:  "https://example.com/latest/",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Traversal path",
+			urlStr:  "https://example.com/latest/..",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BackupFilename(tt.urlStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BackupFilename() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("BackupFilename() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseDate(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
### Summary

utils.ExtractFile rejected any backup URL not ending in `.zip`, so `backup download target-intel` failed with `invalid file format`. This change enables any file format to be downloaded.

Verified: full 42 GiB download completes with sha256 matching the value reported by `/v3/backup`