### PR TITLE
fix: guard against VC_TOKEN silently shadowing the saved config token

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ You should see the version, build date, and changelog URL. If you get "command n
 * Alternatively `vulncheck` will respect the `VC_TOKEN` environment variable.
 * `vulncheck auth` by itself will show other options like checking your status and logging out.
 
+`VC_TOKEN` wins over the saved config file. Because of that, `auth login` and
+`auth logout` refuse while it is set — otherwise they would report success
+having changed nothing that takes effect. Run `vulncheck auth status` to see
+which of the two sources the active token came from.
+
 
 ## Agentic / scripted usage
 
@@ -84,7 +89,7 @@ The CLI is designed to be safe to drive from scripts and AI agents. This section
 
 | Variable                                   | Effect |
 |--------------------------------------------|--------|
-| `VC_TOKEN`                                 | API token. Takes precedence over `~/.config/vulncheck/vulncheck.yaml`. |
+| `VC_TOKEN`                                 | API token. Takes precedence over `~/.config/vulncheck/vulncheck.yaml`. While it is set, `auth login` and `auth logout` refuse rather than writing a config file that would be ignored — `unset VC_TOKEN` first. |
 | `NO_COLOR`                                 | Any non-empty value disables ANSI styling. |
 | `CI` / `BUILD_NUMBER` / `RUN_ID`           | Any of these set implies non-interactive mode (no prompts). |
 
@@ -111,12 +116,13 @@ In `--json` mode, errors are emitted to **stdout** as:
   "error": {
     "code": "auth_required",
     "message": "...",
-    "http_status": 401
+    "http_status": 401,
+    "hint": "..."
   }
 }
 ```
 
-`code` is one of: `internal`, `validation`, `auth_required`, `auth_invalid`, `not_found`, `rate_limited`, `network`, `bad_request`, `cancelled`. `http_status` is omitted for non-HTTP errors.
+`code` is one of: `internal`, `validation`, `auth_required`, `auth_invalid`, `not_found`, `rate_limited`, `network`, `bad_request`, `cancelled`. `http_status` is omitted for non-HTTP errors. `hint` is optional remediation context — present only when the message alone isn't actionable (e.g. naming `VC_TOKEN` as the source of a rejected token) — and is rendered on stderr as `hint: ...` outside `--json` mode.
 
 ### Probe commands
 
@@ -129,6 +135,10 @@ vulncheck version --json
 vulncheck auth status --json
 # {"schema_version": 1, "authenticated": true, "token_source": "env", "user": "...", "email": "..."}
 # Exit 0 even when authenticated=false — agents dispatch on the bool.
+# token_shadowed: true is added when VC_TOKEN is overriding a *different*
+# token saved in vulncheck.yaml — the usual cause of "I logged in but
+# nothing changed". Omitted otherwise, so the CI shape (VC_TOKEN only,
+# no config file) never reports shadowing.
 
 vulncheck commands
 # {"schema_version": 1, "root": {"name":"vulncheck", "subcommands":[...]}, ...}

--- a/cmd/vulncheck/contract_test.go
+++ b/cmd/vulncheck/contract_test.go
@@ -63,6 +63,12 @@ func runCLIAuthed(t *testing.T, args ...string) (stdout, stderr string, exitCode
 }
 
 func runCLIEnv(t *testing.T, token string, args ...string) (stdout, stderr string, exitCode int) {
+	return runCLIHome(t, isolatedHome, token, args...)
+}
+
+// runCLIHome is runCLIEnv with an explicit HOME, for tests that need to seed
+// their own vulncheck.yaml without disturbing the package-wide isolatedHome.
+func runCLIHome(t *testing.T, home, token string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
 	cmd := exec.Command(binPath, args...)
 	var outBuf, errBuf bytes.Buffer
@@ -72,9 +78,9 @@ func runCLIEnv(t *testing.T, token string, args ...string) (stdout, stderr strin
 		// HOME on Unix, USERPROFILE on Windows — both point os.UserHomeDir
 		// at our isolated tree so the tests never touch the developer's
 		// real ~/.config/vulncheck or %APPDATA%.
-		"HOME="+isolatedHome,
-		"USERPROFILE="+isolatedHome,
-		"XDG_CONFIG_HOME="+isolatedHome,
+		"HOME="+home,
+		"USERPROFILE="+home,
+		"XDG_CONFIG_HOME="+home,
 		"VC_TOKEN="+token,
 		"NO_COLOR=1",
 		// Clear CI so Interactive() logic isn't skewed by the outer test env.
@@ -303,5 +309,121 @@ func TestContractScanSbomOnlyJSON(t *testing.T) {
 	// the scan explicitly skipped the vuln lookup.
 	if _, present := m["vulnerabilities"]; present {
 		t.Errorf("sbom-only response should not include a vulnerabilities key; got %v", m)
+	}
+}
+
+// ----- VC_TOKEN shadowing guardrail -----
+
+// homeWithToken returns a fresh HOME containing a vulncheck.yaml that holds
+// the given token, so tests can create the "logged in AND VC_TOKEN set" state.
+func homeWithToken(t *testing.T, token string) string {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".config", "vulncheck")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vulncheck.yaml"),
+		[]byte("token: "+token+"\nindicesdir: \"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// A stale VC_TOKEN silently overrode a saved token, so `auth login` verified
+// the pasted value, skipped the save, and still reported success. It must now
+// refuse rather than pretend.
+func TestContractAuthLoginRefusesWhenEnvTokenSet(t *testing.T) {
+	home := homeWithToken(t, "vulncheck_saved_token_value")
+
+	// --json implies non-interactive, which would trip the CI guard first, so
+	// exercise the plain path and read stderr.
+	_, stderr, exit := runCLIHome(t, home, "vulncheck_env_token_value", "auth", "login", "token")
+	if exit != 2 {
+		t.Fatalf("exit = %d, want 2 (validation)\nstderr: %s", exit, stderr)
+	}
+	if !strings.Contains(stderr, "VC_TOKEN") {
+		t.Errorf("stderr should name VC_TOKEN as the cause; got %q", stderr)
+	}
+	if !strings.Contains(stderr, "unset") {
+		t.Errorf("stderr should tell the user to unset VC_TOKEN; got %q", stderr)
+	}
+
+	// The saved token must be untouched — refusing is not a licence to write.
+	b, err := os.ReadFile(filepath.Join(home, ".config", "vulncheck", "vulncheck.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "vulncheck_saved_token_value") {
+		t.Errorf("saved token should be unchanged after a refused login; file = %q", b)
+	}
+}
+
+// `auth logout` used to revoke the *env* token server-side while deleting a
+// different token from disk, then report success even though the caller was
+// still authenticated. It must refuse instead of touching anything.
+func TestContractAuthLogoutRefusesWhenEnvTokenSet(t *testing.T) {
+	home := homeWithToken(t, "vulncheck_saved_token_value")
+
+	_, stderr, exit := runCLIHome(t, home, "vulncheck_env_token_value", "auth", "logout")
+	if exit != 2 {
+		t.Fatalf("exit = %d, want 2 (validation)\nstderr: %s", exit, stderr)
+	}
+	if !strings.Contains(stderr, "VC_TOKEN") {
+		t.Errorf("stderr should name VC_TOKEN; got %q", stderr)
+	}
+
+	b, err := os.ReadFile(filepath.Join(home, ".config", "vulncheck", "vulncheck.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "vulncheck_saved_token_value") {
+		t.Errorf("logout must not clear the saved token while refusing; file = %q", b)
+	}
+}
+
+// auth status reports the source and the shadowing state so an agent can
+// explain why a freshly saved credential appears to do nothing.
+func TestContractAuthStatusReportsShadowing(t *testing.T) {
+	home := homeWithToken(t, "vulncheck_saved_token_value")
+
+	stdout, _, exit := runCLIHome(t, home, "vulncheck_env_token_value", "auth", "status", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	m := mustJSON(t, stdout)
+	if m["token_source"] != "env" {
+		t.Errorf("token_source = %v, want env", m["token_source"])
+	}
+	if v, _ := m["token_shadowed"].(bool); !v {
+		t.Errorf("token_shadowed = %v, want true", m["token_shadowed"])
+	}
+}
+
+// token_shadowed must stay absent when only VC_TOKEN is set — that is the
+// normal CI shape and it must not look like a misconfiguration.
+func TestContractAuthStatusNoShadowingInCIShape(t *testing.T) {
+	stdout, _, exit := runCLIHome(t, t.TempDir(), "vulncheck_env_token_value", "auth", "status", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	m := mustJSON(t, stdout)
+	if _, present := m["token_shadowed"]; present {
+		t.Errorf("token_shadowed should be omitted when nothing is shadowed; got %v", m)
+	}
+}
+
+// The auth_required envelope gains a hint naming the token source, so the
+// "re-login changes nothing" loop is self-diagnosing.
+func TestContractAuthErrorEnvelopeHint(t *testing.T) {
+	// No token anywhere: no source to name, so no hint.
+	stdout, _, _ := runCLIHome(t, t.TempDir(), "", "indices", "list", "--json")
+	m := mustJSON(t, stdout)
+	errObj, ok := m["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected an error envelope, got %v", m)
+	}
+	if _, present := errObj["hint"]; present {
+		t.Errorf("hint should be omitted when there is no token source to name; got %v", errObj)
 	}
 }

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -72,7 +72,22 @@ type Error struct {
 	Kind       Kind
 	Message    string
 	HTTPStatus int
-	cause      error
+	// Hint is optional remediation context that explains *why* the caller hit
+	// this error, when the message alone is not actionable. Rendered after the
+	// message on stderr and as `error.hint` in the JSON envelope. Additive:
+	// callers that don't know the field simply ignore it.
+	Hint  string
+	cause error
+}
+
+// WithHint attaches remediation context and returns the receiver so it can be
+// chained onto a constructor. No-op on nil.
+func (e *Error) WithHint(format string, args ...any) *Error {
+	if e == nil {
+		return nil
+	}
+	e.Hint = fmt.Sprintf(format, args...)
+	return e
 }
 
 // Error satisfies the error interface.

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -31,6 +31,10 @@ func Command() *cobra.Command {
 				return errs.Validation("%s", i18n.C.AuthLoginErrorCI)
 			}
 
+			if err := pkgLogin.GuardEnvToken(); err != nil {
+				return err
+			}
+
 			if config.HasConfig() && config.HasToken() {
 				if err := pkgLogin.ExistingToken(); err != nil {
 					return err

--- a/pkg/cmd/auth/login/token/token.go
+++ b/pkg/cmd/auth/login/token/token.go
@@ -19,6 +19,10 @@ func Command() *cobra.Command {
 
 func CmdToken(cmd *cobra.Command, args []string) error {
 
+	if err := login.GuardEnvToken(); err != nil {
+		return err
+	}
+
 	var token string
 
 	input := huh.

--- a/pkg/cmd/auth/login/web/web.go
+++ b/pkg/cmd/auth/login/web/web.go
@@ -28,6 +28,10 @@ func Command() *cobra.Command {
 
 func CmdWeb(cmd *cobra.Command, args []string) error {
 
+	if err := login.GuardEnvToken(); err != nil {
+		return err
+	}
+
 	if !inquiry.IsPortAvailable(inquiry.Port) {
 		return fmt.Errorf("this method is not available, try vc auth login token")
 	}

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
+	"github.com/vulncheck-oss/cli/internal/errs"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/i18n"
 	"github.com/vulncheck-oss/cli/pkg/sdk"
@@ -16,12 +17,34 @@ func Command() *cobra.Command {
 		Use:   "logout",
 		Short: i18n.C.AuthLogoutShort,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			res := config.Resolve()
 
-			if !config.HasToken() {
-				return ui.Danger(i18n.C.ErrorNoToken)
+			// Logout can only clear the config file. When VC_TOKEN supplies the
+			// active token, proceeding would revoke the *environment* token
+			// server-side (config.Token() returns it) while deleting a
+			// different token from disk, then report success even though
+			// CheckAuth still passes off the env var. Refuse instead.
+			if res.FromEnv() {
+				e := errs.Validation(
+					"%s is set; `auth logout` cannot unset an environment variable",
+					config.EnvToken)
+				if res.Shadowed {
+					return e.WithHint(
+						"run `unset %s`, then `vulncheck auth logout` again to revoke and remove the token saved in your config file.",
+						config.EnvToken)
+				}
+				return e.WithHint(
+					"run `unset %s` to stop using it, and revoke it with `vulncheck token remove <id>` if it should no longer work.",
+					config.EnvToken)
 			}
 
-			_, err := session.InvalidateToken(config.Token())
+			if res.ConfigToken == "" {
+				return errs.AuthRequired(i18n.C.ErrorNoToken)
+			}
+
+			// Revoke the config-file token specifically, not whatever
+			// Resolve() happened to prefer.
+			_, err := session.InvalidateToken(res.ConfigToken)
 			if err == nil {
 				if err := config.RemoveToken(); err != nil {
 					return ui.Danger(i18n.C.AuthLogoutErrorFailed)
@@ -33,6 +56,8 @@ func Command() *cobra.Command {
 				if err := config.RemoveToken(); err != nil {
 					return ui.Danger(i18n.C.AuthLogoutErrorInvalidToken)
 				}
+				ui.Info(i18n.C.AuthLogoutErrorInvalidToken)
+				return nil
 			}
 
 			return err

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -24,9 +24,25 @@ type authStatus struct {
 	SchemaVersion int    `json:"schema_version"`
 	Authenticated bool   `json:"authenticated"`
 	TokenSource   string `json:"token_source,omitempty"` // "env" | "config" | ""
+	// TokenShadowed reports that VC_TOKEN is overriding a different token
+	// saved in the config file. Agents can key off this to explain why a
+	// freshly saved credential appears to have no effect.
+	TokenShadowed bool   `json:"token_shadowed,omitempty"`
 	User          string `json:"user,omitempty"`
 	Email         string `json:"email,omitempty"`
 	Reason        string `json:"reason,omitempty"` // populated when authenticated=false
+}
+
+// tokenSourceLabel describes the active token's origin in human terms,
+// naming the concrete location so the user knows where to go and change it.
+func tokenSourceLabel(res config.Resolution) string {
+	if res.FromEnv() {
+		return config.EnvToken + " environment variable"
+	}
+	if dir, err := config.Dir(); err == nil {
+		return dir + "/vulncheck.yaml"
+	}
+	return "config file"
 }
 
 func Command() *cobra.Command {
@@ -38,7 +54,9 @@ func Command() *cobra.Command {
 			r := output.FromCmd(cmd)
 			config.Init()
 
-			if !config.HasToken() {
+			res := config.Resolve()
+
+			if res.Token == "" {
 				if r.IsJSON() {
 					// No token = not an error from the agent's POV; emit the
 					// status payload and exit 0 so callers can dispatch on
@@ -51,13 +69,8 @@ func Command() *cobra.Command {
 				return errs.AuthRequired(i18n.C.ErrorNoToken)
 			}
 
-			source := "config"
-			if config.TokenFromEnv() {
-				source = "env"
-			}
-
 			// Verify against the API rather than trusting "token is present".
-			resp, err := session.ConnectWithContext(cmd.Context(), config.Token()).GetMe()
+			resp, err := session.ConnectWithContext(cmd.Context(), res.Token).GetMe()
 			if err != nil {
 				if r.IsJSON() {
 					reason := err.Error()
@@ -66,7 +79,8 @@ func Command() *cobra.Command {
 					}
 					s := newAuthStatus()
 					s.Authenticated = false
-					s.TokenSource = source
+					s.TokenSource = string(res.Source)
+					s.TokenShadowed = res.Shadowed
 					s.Reason = reason
 					return r.JSON(s)
 				}
@@ -76,13 +90,24 @@ func Command() *cobra.Command {
 			if r.IsJSON() {
 				s := newAuthStatus()
 				s.Authenticated = true
-				s.TokenSource = source
+				s.TokenSource = string(res.Source)
+				s.TokenShadowed = res.Shadowed
 				s.User = resp.Data.Name
 				s.Email = resp.Data.Email
 				return r.JSON(s)
 			}
 
-			return login.SaveToken(config.Token())
+			// Human output: name the source explicitly. Which of the two
+			// places the token came from is the single most useful fact when
+			// an unexpected account or a stale credential is in play, and it
+			// was previously only visible via --json.
+			r.Stat("Token source", tokenSourceLabel(res))
+			if res.Shadowed {
+				r.Warn("%s is overriding a different token saved in your config file; run `unset %s` to use the saved one.",
+					config.EnvToken, config.EnvToken)
+			}
+
+			return login.SaveToken(res.Token)
 		},
 	}
 	session.DisableAuthCheck(cmd)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -160,6 +160,31 @@ type errorBody struct {
 	Code       string `json:"code"`
 	Message    string `json:"message"`
 	HTTPStatus int    `json:"http_status,omitempty"`
+	// Hint is optional remediation context. Omitted when empty, so adding it
+	// does not change the envelope for errors that carry no hint.
+	Hint string `json:"hint,omitempty"`
+}
+
+// authHint explains which token source produced the credential that just
+// failed. Without this, a user with a stale VC_TOKEN shadowing a freshly
+// saved config token sees "unauthorized", re-runs `auth login`, is told it
+// succeeded, and hits the same error forever — the CLI never mentions that
+// the token in play came from the environment.
+func authHint(kind errs.Kind) string {
+	if kind != errs.KindAuthInvalid && kind != errs.KindAuthRequired {
+		return ""
+	}
+	res := config.Resolve()
+	switch {
+	case res.Shadowed:
+		return fmt.Sprintf(
+			"the token in use came from %s, which overrides the different token saved in your config file. Run `unset %s` to use the saved one.",
+			config.EnvToken, config.EnvToken)
+	case res.FromEnv():
+		return fmt.Sprintf("the token in use came from %s, not your config file.", config.EnvToken)
+	default:
+		return ""
+	}
 }
 
 func Execute() {
@@ -192,6 +217,10 @@ func Execute() {
 		classified = errs.Wrap(errs.KindCancelled, err, "cancelled")
 	}
 
+	if classified.Hint == "" {
+		classified.Hint = authHint(classified.Kind)
+	}
+
 	if r.IsJSON() {
 		_ = r.JSON(errorEnvelope{
 			SchemaVersion: output.SchemaVersion,
@@ -199,10 +228,14 @@ func Execute() {
 				Code:       string(classified.Kind),
 				Message:    classified.Message,
 				HTTPStatus: classified.HTTPStatus,
+				Hint:       classified.Hint,
 			},
 		})
 	} else {
 		_, _ = fmt.Fprintln(r.Stderr(), ui.Danger(classified.Message).Error())
+		if classified.Hint != "" {
+			_, _ = fmt.Fprintf(r.Stderr(), "hint: %s\n", classified.Hint)
+		}
 	}
 
 	os.Exit(classified.ExitCode())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,23 +24,34 @@ func Init() {
 	environment.Init()
 }
 
+// newViper returns an isolated viper instance. Deliberately NOT the package
+// -level global: viper.Set writes the highest-precedence "override" layer, so
+// a single saveConfig on the global would make every later loadConfig in the
+// process return the written values regardless of what is on disk. That made
+// the save/load round-trip untestable and let a write in one command leak into
+// a read in another.
+func newViper() *viper.Viper {
+	v := viper.New()
+	v.SetConfigName("vulncheck")
+	v.SetConfigType("yaml")
+	return v
+}
+
 func loadConfig() (*Config, error) {
 	dir, err := Dir()
 	if err != nil {
 		return nil, err
 	}
 
-	viper.AddConfigPath(dir)
-	viper.SetConfigName("vulncheck")
-	viper.SetConfigType("yaml")
-	err = viper.ReadInConfig()
-	if err != nil {
+	v := newViper()
+	v.AddConfigPath(dir)
+	if err := v.ReadInConfig(); err != nil {
 		return nil, err
 	}
 
 	// Retrieve values from the configuration
 	var config Config
-	if err := viper.Unmarshal(&config); err != nil {
+	if err := v.Unmarshal(&config); err != nil {
 		log.Fatalf("unable to decode into struct, %v", err)
 	}
 	return &config, nil
@@ -51,13 +62,25 @@ func saveConfig(config *Config) error {
 	if err != nil {
 		return err
 	}
-	viper.AddConfigPath(dir)
-	viper.SetConfigName("vulncheck")
-	viper.SetConfigPermissions(0600)
-	viper.SetConfigType("yaml")
-	viper.Set("Token", config.Token)
-	viper.Set("IndicesDir", config.IndicesDir)
-	return viper.WriteConfigAs(fmt.Sprintf("%s/vulncheck.yaml", dir))
+	v := newViper()
+	v.AddConfigPath(dir)
+	v.SetConfigPermissions(0600)
+	v.Set("Token", config.Token)
+	v.Set("IndicesDir", config.IndicesDir)
+	return v.WriteConfigAs(fmt.Sprintf("%s/vulncheck.yaml", dir))
+}
+
+// mutateConfig applies fn to the config currently on disk and writes it back,
+// so a change to one field never silently drops the others. saveConfig writes
+// every field it knows about, so callers must never hand it a fresh &Config{}
+// built from a single value.
+func mutateConfig(fn func(*Config)) error {
+	config, err := loadConfig()
+	if err != nil {
+		config = &Config{}
+	}
+	fn(config)
+	return saveConfig(config)
 }
 
 func Dir() (string, error) {
@@ -105,12 +128,7 @@ func IndicesDir() (string, error) {
 }
 
 func SetIndicesDir(dir string) error {
-	config, err := loadConfig()
-	if err != nil {
-		config = &Config{}
-	}
-	config.IndicesDir = dir
-	return saveConfig(config)
+	return mutateConfig(func(c *Config) { c.IndicesDir = dir })
 }
 
 func HasConfig() bool {
@@ -118,41 +136,90 @@ func HasConfig() bool {
 	return err == nil
 }
 
+// EnvToken is the environment variable consulted before the config file.
+const EnvToken = "VC_TOKEN"
+
+// TokenSource identifies where the active token came from. The string values
+// are the agent-facing contract emitted by `auth status --json`.
+type TokenSource string
+
+const (
+	// SourceNone means no usable token was found in either location.
+	SourceNone TokenSource = ""
+	// SourceEnv means the token came from the VC_TOKEN environment variable.
+	SourceEnv TokenSource = "env"
+	// SourceConfig means the token came from vulncheck.yaml.
+	SourceConfig TokenSource = "config"
+)
+
+// Resolution is the outcome of resolving a token from all sources. It is the
+// single place precedence is decided; Token/HasToken/TokenFromEnv are thin
+// wrappers so they can never drift apart.
+type Resolution struct {
+	// Token is the token that will actually be sent to the API, or "" if none.
+	Token string
+	// Source says which location Token came from.
+	Source TokenSource
+	// Shadowed reports that VC_TOKEN is overriding a *different* token saved
+	// in vulncheck.yaml. Only true when both are present and their values
+	// differ — identical values cannot confuse anyone, and CI (env set, no
+	// config file) is never shadowed, so this stays quiet in automation.
+	Shadowed bool
+	// ConfigToken is the token stored in vulncheck.yaml, whether or not it
+	// won. Used to report shadowing; never render it to the user.
+	ConfigToken string
+}
+
+// FromEnv reports whether the active token came from the environment.
+func (r Resolution) FromEnv() bool { return r.Source == SourceEnv }
+
+// Resolve determines the active token. Precedence: VC_TOKEN, then the
+// token in vulncheck.yaml. A value that fails ValidToken is treated as absent
+// in both positions, so a blank or whitespace entry in either place falls
+// through to the next source rather than being sent to the API.
+func Resolve() Resolution {
+	var res Resolution
+
+	if config, err := loadConfig(); err == nil && ValidToken(config.Token) {
+		res.ConfigToken = config.Token
+	}
+
+	if env := os.Getenv(EnvToken); ValidToken(env) {
+		res.Token = env
+		res.Source = SourceEnv
+		res.Shadowed = res.ConfigToken != "" && res.ConfigToken != env
+		return res
+	}
+
+	if res.ConfigToken != "" {
+		res.Token = res.ConfigToken
+		res.Source = SourceConfig
+	}
+	return res
+}
+
 func TokenFromEnv() bool {
-	return ValidToken(os.Getenv("VC_TOKEN"))
+	return Resolve().FromEnv()
 }
 
 func Token() string {
-
-	token := os.Getenv("VC_TOKEN")
-
-	if token != "" && ValidToken(token) {
-		return token
-	}
-
-	config, err := loadConfig()
-	if err != nil {
-		return ""
-	}
-	return config.Token
+	return Resolve().Token
 }
 
 func HasToken() bool {
-	return Token() != ""
+	return Resolve().Token != ""
 }
 
+// SaveToken writes token to vulncheck.yaml, preserving every other setting.
 func SaveToken(token string) error {
-	config := &Config{
-		Token: token,
-	}
-	return saveConfig(config)
+	return mutateConfig(func(c *Config) { c.Token = token })
 }
 
+// RemoveToken clears the saved token, preserving every other setting.
+// Note this only clears the *config file*; if VC_TOKEN is set the caller
+// remains authenticated. Check Resolve().FromEnv() before claiming otherwise.
 func RemoveToken() error {
-	config := &Config{
-		Token: "",
-	}
-	return saveConfig(config)
+	return mutateConfig(func(c *Config) { c.Token = "" })
 }
 
 func ValidToken(token string) bool {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 )
 
@@ -38,17 +37,11 @@ func TestValidToken(t *testing.T) {
 }
 
 func TestSaveAndLoadConfig(t *testing.T) {
-	// Setup: Create a temporary directory for config
-	tempDir := t.TempDir()
-	homeDir := os.Getenv("HOME") // Save original HOME
-	if err := os.Setenv("HOME", tempDir); err != nil {
-		t.Fatalf("Failed to set HOME env var: %v", err)
-	}
-	defer func() {
-		if err := os.Setenv("HOME", homeDir); err != nil {
-			t.Errorf("Failed to restore HOME env var: %v", err)
-		}
-	}()
+	// isolateHome sets both HOME and USERPROFILE, so config.Dir() resolves
+	// into the temp tree on Windows too. Setting HOME alone left this writing
+	// into the runner's real profile, where the token below then leaked into
+	// every other test in the package.
+	isolateHome(t)
 
 	expectedToken := "vulncheck_testtoken1234567890abcdefghijklmnopqrstuvw"
 	config := &Config{Token: expectedToken}

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -1,0 +1,191 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeConfigToken seeds a config file under a temp HOME and returns nothing;
+// callers use Resolve() to observe it.
+func writeConfigToken(t *testing.T, token string) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), ".config", "vulncheck")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// t.TempDir() differs per call, so derive HOME from the dir we just made.
+	t.Setenv("HOME", filepath.Dir(filepath.Dir(dir)))
+	if err := os.WriteFile(filepath.Join(dir, "vulncheck.yaml"),
+		[]byte("token: "+token+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolvePrecedence(t *testing.T) {
+	tests := []struct {
+		name         string
+		env          string
+		configToken  string
+		wantToken    string
+		wantSource   TokenSource
+		wantShadowed bool
+	}{
+		{
+			name:       "env only",
+			env:        "env_token",
+			wantToken:  "env_token",
+			wantSource: SourceEnv,
+		},
+		{
+			name:        "config only",
+			configToken: "file_token",
+			wantToken:   "file_token",
+			wantSource:  SourceConfig,
+		},
+		{
+			name:         "env shadows a different config token",
+			env:          "env_token",
+			configToken:  "file_token",
+			wantToken:    "env_token",
+			wantSource:   SourceEnv,
+			wantShadowed: true,
+		},
+		{
+			name:        "identical values are not shadowing",
+			env:         "same_token",
+			configToken: "same_token",
+			wantToken:   "same_token",
+			wantSource:  SourceEnv,
+			// No possible confusion, so no warning should ever fire.
+			wantShadowed: false,
+		},
+		{
+			name:       "neither source",
+			wantToken:  "",
+			wantSource: SourceNone,
+		},
+		{
+			name:        "blank env falls through to config",
+			env:         "   ",
+			configToken: "file_token",
+			wantToken:   "file_token",
+			wantSource:  SourceConfig,
+		},
+		{
+			name:        "whitespace-only config token is treated as absent",
+			configToken: `"   "`,
+			wantToken:   "",
+			wantSource:  SourceNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.configToken != "" {
+				writeConfigToken(t, tt.configToken)
+			} else {
+				t.Setenv("HOME", t.TempDir())
+			}
+			t.Setenv(EnvToken, tt.env)
+
+			got := Resolve()
+			if got.Token != tt.wantToken {
+				t.Errorf("Token = %q, want %q", got.Token, tt.wantToken)
+			}
+			if got.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", got.Source, tt.wantSource)
+			}
+			if got.Shadowed != tt.wantShadowed {
+				t.Errorf("Shadowed = %v, want %v", got.Shadowed, tt.wantShadowed)
+			}
+		})
+	}
+}
+
+// The three public accessors are wrappers over Resolve; assert they cannot
+// disagree with it the way the previous independent implementations could.
+func TestAccessorsAgreeWithResolve(t *testing.T) {
+	writeConfigToken(t, `"   "`) // whitespace: previously HasToken=true, CheckAuth=false
+	t.Setenv(EnvToken, "")
+
+	res := Resolve()
+	if HasToken() != (res.Token != "") {
+		t.Errorf("HasToken()=%v but Resolve().Token=%q", HasToken(), res.Token)
+	}
+	if Token() != res.Token {
+		t.Errorf("Token()=%q but Resolve().Token=%q", Token(), res.Token)
+	}
+	if TokenFromEnv() != res.FromEnv() {
+		t.Errorf("TokenFromEnv()=%v but Resolve().FromEnv()=%v", TokenFromEnv(), res.FromEnv())
+	}
+	if HasToken() {
+		t.Error("a whitespace-only config token must not count as a token")
+	}
+}
+
+// saveConfig must not leak values into later loadConfig calls via viper's
+// override layer, and loadConfig must reflect what is actually on disk.
+func TestLoadConfigReadsDisk(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := saveConfig(&Config{Token: "from_save"}); err != nil {
+		t.Fatal(err)
+	}
+
+	p := filepath.Join(home, ".config", "vulncheck", "vulncheck.yaml")
+	if err := os.WriteFile(p, []byte("token: from_disk\nindicesdir: \"\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Token != "from_disk" {
+		t.Errorf("loadConfig() token = %q, want %q (viper override layer leaked)", got.Token, "from_disk")
+	}
+}
+
+// SaveToken / RemoveToken change one field; they must not drop the others.
+func TestTokenWritesPreserveIndicesDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".config", "vulncheck")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, "vulncheck.yaml")
+	if err := os.WriteFile(p, []byte("token: old\nindicesdir: /data/my-indices\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveToken("new_token"); err != nil {
+		t.Fatal(err)
+	}
+	c, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.IndicesDir != "/data/my-indices" {
+		t.Errorf("after SaveToken, IndicesDir = %q, want %q", c.IndicesDir, "/data/my-indices")
+	}
+	if c.Token != "new_token" {
+		t.Errorf("after SaveToken, Token = %q, want %q", c.Token, "new_token")
+	}
+
+	if err := RemoveToken(); err != nil {
+		t.Fatal(err)
+	}
+	c, err = loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.IndicesDir != "/data/my-indices" {
+		t.Errorf("after RemoveToken, IndicesDir = %q, want %q", c.IndicesDir, "/data/my-indices")
+	}
+	if c.Token != "" {
+		t.Errorf("after RemoveToken, Token = %q, want empty", c.Token)
+	}
+}

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -6,16 +6,28 @@ import (
 	"testing"
 )
 
-// writeConfigToken seeds a config file under a temp HOME and returns nothing;
-// callers use Resolve() to observe it.
+// isolateHome points config.Dir() at a fresh temp directory and returns it.
+//
+// os.UserHomeDir reads USERPROFILE on Windows and HOME elsewhere, so setting
+// only HOME leaves Windows resolving the runner's real profile — every test in
+// the package then shares one config file and they contaminate each other.
+// Always set both.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+// writeConfigToken seeds a config file under an isolated home. Callers use
+// Resolve() to observe it.
 func writeConfigToken(t *testing.T, token string) {
 	t.Helper()
-	dir := filepath.Join(t.TempDir(), ".config", "vulncheck")
+	dir := filepath.Join(isolateHome(t), ".config", "vulncheck")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatal(err)
 	}
-	// t.TempDir() differs per call, so derive HOME from the dir we just made.
-	t.Setenv("HOME", filepath.Dir(filepath.Dir(dir)))
 	if err := os.WriteFile(filepath.Join(dir, "vulncheck.yaml"),
 		[]byte("token: "+token+"\n"), 0600); err != nil {
 		t.Fatal(err)
@@ -85,7 +97,7 @@ func TestResolvePrecedence(t *testing.T) {
 			if tt.configToken != "" {
 				writeConfigToken(t, tt.configToken)
 			} else {
-				t.Setenv("HOME", t.TempDir())
+				isolateHome(t)
 			}
 			t.Setenv(EnvToken, tt.env)
 
@@ -127,8 +139,7 @@ func TestAccessorsAgreeWithResolve(t *testing.T) {
 // saveConfig must not leak values into later loadConfig calls via viper's
 // override layer, and loadConfig must reflect what is actually on disk.
 func TestLoadConfigReadsDisk(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := isolateHome(t)
 
 	if err := saveConfig(&Config{Token: "from_save"}); err != nil {
 		t.Fatal(err)
@@ -150,8 +161,7 @@ func TestLoadConfigReadsDisk(t *testing.T) {
 
 // SaveToken / RemoveToken change one field; they must not drop the others.
 func TestTokenWritesPreserveIndicesDir(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := isolateHome(t)
 	dir := filepath.Join(home, ".config", "vulncheck")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		t.Fatal(err)

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -5,11 +5,39 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/huh/spinner"
+	"github.com/vulncheck-oss/cli/internal/errs"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/sdk"
 	"github.com/vulncheck-oss/cli/pkg/session"
 	"github.com/vulncheck-oss/cli/pkg/ui"
 )
+
+// GuardEnvToken refuses a login when VC_TOKEN is set. Every login path writes
+// to the config file, but Resolve() prefers the environment — so the write
+// would be dead on arrival. Previously these paths verified the pasted token,
+// skipped the save, and still printed "Authenticated as ...", which is why a
+// user with a stale VC_TOKEN could log in repeatedly and never change anything.
+//
+// Callers must invoke this *before* prompting, so the user isn't asked to paste
+// a token or complete a browser flow that is going to be discarded.
+func GuardEnvToken() error {
+	res := config.Resolve()
+	if !res.FromEnv() {
+		return nil
+	}
+
+	e := errs.Validation(
+		"%s is set and takes precedence over the config file, so logging in would have no effect",
+		config.EnvToken)
+	if res.Shadowed {
+		return e.WithHint(
+			"a different token is already saved in your config file. Run `unset %s` to use it, or keep using the environment token as-is.",
+			config.EnvToken)
+	}
+	return e.WithHint(
+		"run `unset %s` first if you want credentials stored in the config file.",
+		config.EnvToken)
+}
 
 func ChooseAuthMethod() (string, error) {
 
@@ -45,7 +73,11 @@ func ExistingToken() error {
 	}
 
 	if logoutChoice {
-		if _, err := session.InvalidateToken(config.Token()); err != nil {
+		// Revoke the token saved on disk specifically. Callers reach this only
+		// after GuardEnvToken, so Resolve() would return the same value today —
+		// but naming ConfigToken keeps it correct if that ordering ever changes,
+		// rather than silently revoking the caller's environment credential.
+		if _, err := session.InvalidateToken(config.Resolve().ConfigToken); err != nil {
 			if err := config.RemoveToken(); err != nil {
 				return ui.Error("Failed to remove token from config")
 			}
@@ -82,10 +114,18 @@ func SaveToken(token string) error {
 		return ui.Error("Token verification failed: %v", err)
 	}
 
-	if !config.TokenFromEnv() {
-		if err := config.SaveToken(token); err != nil {
-			return ui.Error("Failed to save token: %v", err)
-		}
+	// An env token still wins after this write, so don't imply the save
+	// changed which credential is in use. Login paths are already blocked by
+	// GuardEnvToken; this branch is reached by `auth status`, which re-verifies
+	// the active token without wanting to persist an environment value to disk.
+	if config.Resolve().FromEnv() {
+		ui.Info(fmt.Sprintf("Verified as %s (%s) using the token from %s; config file not modified",
+			res.Data.Name, res.Data.Email, config.EnvToken))
+		return nil
+	}
+
+	if err := config.SaveToken(token); err != nil {
+		return ui.Error("Failed to save token: %v", err)
 	}
 	ui.Success(fmt.Sprintf("Authenticated as %s (%s)", res.Data.Name, res.Data.Email))
 	return nil

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -25,12 +25,12 @@ type Me struct {
 	Avatar string
 }
 
+// CheckAuth reports whether a usable token was found in any source.
+// config.Resolve already rejects invalid values in both positions, so this is
+// simply "did we resolve anything" — it must not re-validate independently, or
+// it drifts from what HasToken/Token report.
 func CheckAuth() bool {
-	token := config.Token()
-	if token != "" && config.ValidToken(token) {
-		return true
-	}
-	return false
+	return config.Resolve().Token != ""
 }
 
 func ChangelogURL(version string) string {


### PR DESCRIPTION
## Problem
`VC_TOKEN` takes precedence over `~/.config/vulncheck/vulncheck.yaml`, which is documented and correct. But `config.Token()` short-circuited on the env var, so every auth **write** path operated on the environment token while reporting success about the config file. Three consequences, each silent:
1. **`auth login` claimed success and did nothing.** `login.SaveToken` verified the pasted token, then `if !config.TokenFromEnv()` skipped the save, then unconditionally printed `Authenticated as ...`. A user chasing a 401 from a stale `VC_TOKEN` could re-login forever and never change what was in force.
2. **`auth logout` revoked the wrong token and destroyed both.** It called `InvalidateToken(config.Token())` — the *environment* token — then cleared the config file's *different* token, then reported success. `CheckAuth()` still passed off the env var, so the user was not even logged out.
3. **401s never named the source**, which is what turned (1) into a loop.
A fourth case stays silent by nature: a valid `VC_TOKEN` for the *wrong account* produces no error at all.

## Approach
Resolve precedence in exactly one place. `config.Resolve()` returns the active token, its source, and whether `VC_TOKEN` is overriding a **different** saved token. `Token()`, `HasToken()`, `TokenFromEnv()` and `session.CheckAuth()` become wrappers, so they cannot drift apart as they had.
`Shadowed` requires the two values to *differ*. That is what makes a guardrail affordable: CI sets `VC_TOKEN` with no config file, so it is never shadowed and never warns.
Then: refuse rather than pretend on the write paths, and name the source on the read paths.

## Scenario 1 — `auth logout` with `VC_TOKEN` set
The sharpest case. Setup for both runs: `VC_TOKEN` holds one token, `vulncheck.yaml` holds a different one plus a custom `indicesdir`.
**Before** — the 401 is the *env* token being rejected for revocation; the config file is wiped anyway, taking `indicesdir` with it:
```
$ vulncheck auth logout
    ✗ unauthorized: token is missing or invalid
    [exit 3]
$ cat ~/.config/vulncheck/vulncheck.yaml   # afterwards
    indicesdir: ""
    token: ""
```
**After** — refuses, touches nothing:
```
$ vulncheck auth logout
    ✗ VC_TOKEN is set; `auth logout` cannot unset an environment variable
    hint: run `unset VC_TOKEN`, then `vulncheck auth logout` again to revoke and remove the token saved in your config file.
    [exit 2]
$ cat ~/.config/vulncheck/vulncheck.yaml   # afterwards
    token: vulncheck_SAVEDTOKEN000000000000000000000000000000000000000000000000000000
    indicesdir: /data/my-indices
```
## Scenario 2 — the silent no-op, via `auth status`
`auth status` funnels through the same `login.SaveToken` as every login path, so it demonstrates the silent-skip without a TTY. Run against a local stub API returning a valid `/me`, with `VC_TOKEN` shadowing a different saved token.
**Before** — a clean success tick. Nothing indicates the token came from the environment, that a different token is saved, or that the config file was left alone:
```
$ vulncheck auth status
    ✓ Authenticated as ci-bot (ci-bot@example.com)
    [exit 0]
```
**After**:
```
$ vulncheck auth status
    Token source: VC_TOKEN environment variable
    VC_TOKEN is overriding a different token saved in your config file; run `unset VC_TOKEN` to use the saved one.
    i Verified as ci-bot (ci-bot@example.com) using the token from VC_TOKEN; config file not modified
    [exit 0]
```
## Scenario 3 — `auth login` refuses instead of no-op'ing
```
$ vulncheck auth login token
    ✗ VC_TOKEN is set and takes precedence over the config file, so logging in would have no effect
    hint: a different token is already saved in your config file. Run `unset VC_TOKEN` to use it, or keep using the environment token as-is.
    [exit 2]
$ cat ~/.config/vulncheck/vulncheck.yaml   # unchanged — refusing is not a licence to write
    token: vulncheck_SAVEDTOKEN000000000000000000000000000000000000000000000000000000
    indicesdir: /data/my-indices
```
The guard runs on all three entry points (`auth login`, `auth login token`, `auth login web`) **before** any prompt, so nobody pastes a token or completes a browser flow that is going to be discarded.
## Scenario 4 — 401s now name the source
Same command, same 401, on a shadowed env token:
**Before**
```
$ vulncheck indices list
    ✗ unauthorized: token is missing or invalid
    [exit 3]
```
**After**
```
$ vulncheck indices list
    ✗ unauthorized: token is missing or invalid
    hint: the token in use came from VC_TOKEN, which overrides the different token saved in your config file. Run `unset VC_TOKEN` to use the saved one.
    [exit 3]
```
Wording adapts when nothing is shadowed (env token, no saved token):
```
    hint: the token in use came from VC_TOKEN, not your config file.
```
And in `--json`, as an additive `error.hint`:
```json
{
  "schema_version": 1,
  "error": {
    "code": "auth_invalid",
    "message": "unauthorized: token is missing or invalid",
    "http_status": 401,
    "hint": "the token in use came from VC_TOKEN, which overrides the different token saved in your config file. Run `unset VC_TOKEN` to use the saved one."
  }
}
```
## Scenario 5 — `auth status --json` gains `token_shadowed`
**Before** → **After**, same inputs:
```diff
 {
   "schema_version": 1,
   "authenticated": true,
   "token_source": "env",
+  "token_shadowed": true,
   "user": "ci-bot",
   "email": "ci-bot@example.com"
 }
```
## Scenario 6 — CI must stay quiet
`VC_TOKEN` set, **no** config file — the normal automation shape. Byte-identical before and after, and `token_shadowed` is absent rather than `false`:
```
$ vulncheck auth status --json
    {
      "schema_version": 1,
      "authenticated": true,
      "token_source": "env",
      "user": "ci-bot",
      "email": "ci-bot@example.com"
    }
    [exit 0]
```
---
## Two prerequisite bugs fixed
The guardrail has to read the config file accurately, which surfaced these. Both new tests **fail on the pre-change code**:
```
=== against the OLD config.go ===
    regress_test.go:24: loadConfig() token = "from_save", want "from_disk" (viper override layer leaked)
--- FAIL: TestLoadConfigReadsDisk (0.01s)
    regress_test.go:47: after SaveToken, IndicesDir = "", want "/data/my-indices"
--- FAIL: TestTokenWritesPreserveIndicesDir (0.01s)
FAIL
=== same two against the NEW config.go ===
ok      github.com/vulncheck-oss/cli/pkg/config  0.352s
```
- **`loadConfig`/`saveConfig` now use an isolated `viper.New()`** instead of the package global. `viper.Set` writes the highest-precedence *override* layer, so one `saveConfig` made every later `loadConfig` in the process return the written values regardless of what was on disk. This also made the existing `TestSaveAndLoadConfig` vacuous — it only ever read viper's in-memory override, never the file.
- **`SaveToken`/`RemoveToken` go through a read-modify-write helper** instead of building a fresh `&Config{}` from one field, so they stop wiping a configured `IndicesDir` (visible in Scenario 1's *before* output).
## Also fixed
`Resolve` runs `ValidToken` on **both** positions, closing a gap where a whitespace-only token in the config file made `HasToken()` true but `CheckAuth()` false — the root gate rejected with "no token found" while `auth status` proceeded to an API call.
## Behaviour change
Scripts running `auth login` with `VC_TOKEN` set previously exited **0 as a silent no-op** and now exit **2**. That is the point of the change, but it is the one compatibility break. `auth logout` likewise now refuses instead of destroying two credentials.
## Not included
The fourth failure mode — a valid `VC_TOKEN` for the wrong account — is still silent outside `auth status`. Catching it needs a warning on *every* command, which would nag the legitimate `VC_TOKEN=$DEV_TOKEN vulncheck ...` workflow and would need its own opt-out env var. Deliberately left out; happy to add it if reviewers want the coverage.
## Testing
- `pkg/config/resolve_test.go` — precedence table (env-only, config-only, shadowing, identical values, neither, blank env falls through, whitespace-only config token), accessor agreement, and the two regressions above.
- `cmd/vulncheck/contract_test.go` — end-to-end over the built binary: login refuses and leaves the file intact, logout refuses and leaves the file intact, `token_shadowed` present when shadowed and absent in the CI shape, `hint` omitted when there is no source to name.
- Full suite green; `go vet` clean; touched files `gofmt`-clean.
