### PR TITLE
fix: reject unknown --enrich scopes instead of silently ignoring them

### DIFF
--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -58,6 +58,102 @@ func GetSBOM(dir string, opts SBOMOptions) (*sbom.SBOM, error) {
 	return sbm, nil
 }
 
+// Scope alias groups, mirroring syft's own task-name mapping
+// (internal/task/package_tasks.go). Every name syft's CLI accepts for a
+// language is listed so `--enrich <alias>` behaves the same here as it would
+// under syft itself. These are the single source of truth for both
+// buildSBOMConfig's dispatch and ValidateEnrich's accepted set, so a scope can
+// never be dispatchable but unrecognised (or vice versa).
+var (
+	scopeGolang     = []string{"golang", "go"}
+	scopeJavaScript = []string{"javascript", "node", "npm"}
+	scopePython     = []string{"python"}
+	scopeJava       = []string{"java", "maven"}
+
+	// scopeMeta are the collective directives syft accepts alongside language
+	// names. Their precedence is handled by enrichmentScope.
+	scopeMeta = []string{"all", "none"}
+)
+
+// vcpkgUnsupported explains why we reject a scope syft itself accepts. Kept as
+// a named constant because it is the one rejection that is a deliberate product
+// decision rather than a typo, and the reasoning needs to survive contact with
+// the next person who wonders why parity is missing.
+//
+// Must stay a single line: ui.Error renders through lipgloss, which pads a
+// multi-line block out to its widest line and leaves trailing whitespace on
+// every row.
+const vcpkgUnsupported = "--enrich %s is not supported by this CLI (syft accepts it, but it clones git registries named in " +
+	"the scanned repository's own vcpkg.json). Packages declared in vcpkg.json are still catalogued without it; " +
+	"run syft directly if you need registry resolution. Supported scopes: all, golang, java, javascript, python"
+
+// unsupportedScopes are scopes syft recognises that this CLI deliberately does
+// not wire up, mapped to the explanation shown to the user. syft enables vcpkg
+// registry cloning under both "vcpkg" and "cpp", so both are rejected.
+var unsupportedScopes = map[string]string{
+	"vcpkg": vcpkgUnsupported,
+	"cpp":   vcpkgUnsupported,
+}
+
+// ValidateEnrich checks --enrich directives before any cataloguing starts.
+// Without it an unrecognised scope is silently ignored: enrichmentScope simply
+// never matches it, so `--enrich typo` or `--enrich vcpkg` looks accepted and
+// quietly enriches nothing. Failing up front is the difference between "your
+// flag did nothing" and "your SBOM is missing the metadata you asked for".
+//
+// Matching is case-sensitive and the +/- prefixes are accepted, both for parity
+// with syft, whose own directive comparison is an exact match against lowercase
+// task names. Scopes in unsupportedScopes are rejected only in their enabling
+// forms; see the negation carve-out below.
+func ValidateEnrich(directives []string) error {
+	known := make(map[string]struct{})
+	for _, group := range [][]string{scopeMeta, scopeGolang, scopeJavaScript, scopePython, scopeJava} {
+		for _, name := range group {
+			known[name] = struct{}{}
+		}
+	}
+
+	for _, d := range directives {
+		scope, negated := normalizeScope(d)
+		if scope == "" {
+			return fmt.Errorf("empty --enrich scope in %q; supported scopes: %s", d, supportedScopes())
+		}
+		if reason, ok := unsupportedScopes[scope]; ok {
+			// A negated directive asks for the behaviour we already have, so
+			// honour it rather than failing a command whose intent we satisfy —
+			// `all,-vcpkg` is what someone hardening a syft invocation writes.
+			// Only the enabling forms are an error.
+			if negated {
+				continue
+			}
+			return fmt.Errorf(reason, scope)
+		}
+		if _, ok := known[scope]; !ok {
+			return fmt.Errorf("unknown --enrich scope %q; supported scopes: %s", scope, supportedScopes())
+		}
+	}
+	return nil
+}
+
+// supportedScopes renders the publicised scope list for error messages. It
+// mirrors syft's publicisedEnrichmentOptions rather than every alias, so the
+// hint stays short and matches what --help advertises.
+func supportedScopes() string {
+	return "all, golang, java, javascript, python"
+}
+
+// normalizeScope strips the +/- prefix from a directive, returning the bare
+// scope name and whether it was negated. Shared by enrichmentScope and
+// ValidateEnrich so validation accepts exactly the syntax the dispatcher
+// understands.
+func normalizeScope(d string) (scope string, negated bool) {
+	d = strings.TrimPrefix(d, "+")
+	if strings.HasPrefix(d, "-") {
+		return d[1:], true
+	}
+	return d, false
+}
+
 // buildSBOMConfig returns nil when no options need setting, preserving syft's
 // default behaviour end-to-end. When Enrich is populated it starts from syft's
 // defaults and flips the same per-language fields that syft's own CLI flips
@@ -77,22 +173,22 @@ func buildSBOMConfig(opts SBOMOptions) *syft.CreateSBOMConfig {
 	// Advertising only the publicised names in --help keeps parity with syft's help
 	// output, but users typing an alias syft accepts should still get the same
 	// behaviour they'd get from `syft --enrich <alias>`.
-	if enrichmentScope(opts.Enrich, "golang", "go") {
+	if enrichmentScope(opts.Enrich, scopeGolang...) {
 		pkgCfg.Golang = pkgCfg.Golang.
 			WithSearchLocalModCacheLicenses(true).
 			WithSearchLocalVendorLicenses(true).
 			WithSearchRemoteLicenses(true).
 			WithUsePackagesLib(true)
 	}
-	if enrichmentScope(opts.Enrich, "javascript", "node", "npm") {
+	if enrichmentScope(opts.Enrich, scopeJavaScript...) {
 		pkgCfg.JavaScript = pkgCfg.JavaScript.WithSearchRemoteLicenses(true)
 	}
-	if enrichmentScope(opts.Enrich, "python") {
+	if enrichmentScope(opts.Enrich, scopePython...) {
 		pkgCfg.Python = pkgCfg.Python.
 			WithSearchRemoteLicenses(true).
 			WithGuessUnpinnedRequirements(true)
 	}
-	if enrichmentScope(opts.Enrich, "java", "maven") {
+	if enrichmentScope(opts.Enrich, scopeJava...) {
 		pkgCfg.JavaArchive = pkgCfg.JavaArchive.
 			WithUseMavenLocalRepository(true).
 			WithUseNetwork(true)
@@ -109,12 +205,8 @@ func buildSBOMConfig(opts SBOMOptions) *syft.CreateSBOMConfig {
 func enrichmentScope(directives []string, aliases ...string) bool {
 	lookup := func(name string) (found, enable bool) {
 		for _, d := range directives {
-			d = strings.TrimPrefix(d, "+")
-			neg := strings.HasPrefix(d, "-")
-			if neg {
-				d = d[1:]
-			}
-			if d == name {
+			scope, neg := normalizeScope(d)
+			if scope == name {
 				return true, !neg
 			}
 		}

--- a/pkg/bill/bill_test.go
+++ b/pkg/bill/bill_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/vulncheck-oss/cli/pkg/cache"
 	"github.com/vulncheck-oss/cli/pkg/models"
@@ -536,5 +537,27 @@ func TestValidateEnrichAgreesWithDispatch(t *testing.T) {
 		if enrichmentScope([]string{"-" + scope}, scope) {
 			t.Errorf("scope %q negated must not enable anything", scope)
 		}
+	}
+}
+
+// The whole point of rejecting vcpkg is that we never turn on registry
+// cloning, so pin that directly against syft's config rather than trusting the
+// dispatch table. syft 1.51 added this scope to its publicised list, and a
+// future bump could quietly start defaulting it on.
+func TestEnrichAllDoesNotEnableVcpkgCloning(t *testing.T) {
+	for _, directives := range [][]string{{"all"}, {"all", "-vcpkg"}, {"golang", "java", "javascript", "python"}} {
+		cfg := buildSBOMConfig(SBOMOptions{Enrich: directives})
+		if cfg == nil {
+			t.Fatalf("buildSBOMConfig(%v) = nil, want a config", directives)
+		}
+		if cfg.Packages.Cpp.VcpkgAllowGitClone {
+			t.Errorf("--enrich %v enabled vcpkg git cloning; it must stay off", directives)
+		}
+	}
+
+	// syft's own default must also be off, otherwise the nil-config path
+	// (no --enrich at all) would clone registries.
+	if pkgcataloging.DefaultConfig().Cpp.VcpkgAllowGitClone {
+		t.Error("syft's default config now enables vcpkg git cloning; the --enrich rejection is no longer sufficient")
 	}
 }

--- a/pkg/bill/bill_test.go
+++ b/pkg/bill/bill_test.go
@@ -3,6 +3,7 @@ package bill
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/anchore/syft/syft"
@@ -129,8 +130,8 @@ func TestGetPURLDetail(t *testing.T) {
 	refs := []InputSbomRef{
 		{SbomRef: "ref-1", PURL: "pkg:generic/qnx_software_development_platform@7.1"},
 		{SbomRef: "ref-2", PURL: "pkg:generic/qnx_software_development_platform@7.1"}, // duplicate
-		{SbomRef: "ref-3", PURL: ""},                                                  // empty
-		{SbomRef: "ref-4", PURL: "pkg:github/actions/checkout@v3"},                    // filtered
+		{SbomRef: "ref-3", PURL: ""},                               // empty
+		{SbomRef: "ref-4", PURL: "pkg:github/actions/checkout@v3"}, // filtered
 		{SbomRef: "ref-5", PURL: "pkg:generic/other@1.0"},
 	}
 
@@ -168,7 +169,7 @@ func TestGetCPEDetail(t *testing.T) {
 			CPE: "cpe:2.3:a:blackberry:qnx_software_development_platform:7.1:*:*:*:*:*:*:*"},
 		{SbomRef: "ref-2", PURL: "pkg:generic/qnx_software_development_platform@7.1",
 			CPE: "cpe:2.3:a:blackberry:qnx_software_development_platform:7.1:*:*:*:*:*:*:*"}, // duplicate
-		{SbomRef: "ref-3", PURL: "pkg:generic/other@1.0", CPE: ""},                          // no CPE
+		{SbomRef: "ref-3", PURL: "pkg:generic/other@1.0", CPE: ""}, // no CPE
 	}
 
 	got := GetCPEDetail(nil, refs)
@@ -411,4 +412,129 @@ func TestGetOfflineMeta(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestValidateEnrich(t *testing.T) {
+	cases := []struct {
+		name       string
+		directives []string
+		wantErr    bool
+		wantSubstr string
+	}{
+		{name: "no directives", directives: nil},
+		{name: "empty slice", directives: []string{}},
+		{name: "publicised scopes", directives: []string{"all", "golang", "java", "javascript", "python"}},
+		{name: "aliases syft accepts", directives: []string{"go", "node", "npm", "maven"}},
+		{name: "none directive", directives: []string{"none"}},
+		{name: "plus prefix", directives: []string{"+golang"}},
+		{name: "minus prefix", directives: []string{"all", "-java"}},
+
+		{
+			name:       "unknown scope",
+			directives: []string{"rust"},
+			wantErr:    true,
+			wantSubstr: `unknown --enrich scope "rust"`,
+		},
+		{
+			name:       "typo is rejected not ignored",
+			directives: []string{"golang", "pythonn"},
+			wantErr:    true,
+			wantSubstr: `unknown --enrich scope "pythonn"`,
+		},
+		{
+			name:       "case mismatch rejected for syft parity",
+			directives: []string{"Golang"},
+			wantErr:    true,
+			wantSubstr: `unknown --enrich scope "Golang"`,
+		},
+		{
+			name:       "empty element from trailing comma",
+			directives: []string{"golang", ""},
+			wantErr:    true,
+			wantSubstr: "empty --enrich scope",
+		},
+		{
+			name:       "bare minus is an empty scope",
+			directives: []string{"-"},
+			wantErr:    true,
+			wantSubstr: "empty --enrich scope",
+		},
+		{
+			name:       "vcpkg rejected with reason",
+			directives: []string{"vcpkg"},
+			wantErr:    true,
+			wantSubstr: "not supported by this CLI",
+		},
+		{
+			name:       "cpp alias rejected too",
+			directives: []string{"cpp"},
+			wantErr:    true,
+			wantSubstr: "not supported by this CLI",
+		},
+		{
+			// Disabling an unsupported scope asks for the behaviour we already
+			// have, so it is honoured rather than rejected.
+			name:       "negated vcpkg accepted",
+			directives: []string{"all", "-vcpkg"},
+		},
+		{
+			name:       "negated cpp accepted",
+			directives: []string{"-cpp"},
+		},
+		{
+			name:       "plus-prefixed vcpkg still rejected",
+			directives: []string{"+vcpkg"},
+			wantErr:    true,
+			wantSubstr: "not supported by this CLI",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEnrich(tc.directives)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateEnrich(%v) = nil, want error", tc.directives)
+				}
+				if !strings.Contains(err.Error(), tc.wantSubstr) {
+					t.Errorf("ValidateEnrich(%v) error = %q, want it to contain %q", tc.directives, err, tc.wantSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ValidateEnrich(%v) = %v, want nil", tc.directives, err)
+			}
+		})
+	}
+}
+
+// Every scope ValidateEnrich accepts must be one buildSBOMConfig can actually
+// dispatch on, otherwise a scope could pass validation and still silently do
+// nothing - the exact failure this validation exists to prevent.
+func TestValidateEnrichAgreesWithDispatch(t *testing.T) {
+	languageScopes := [][]string{scopeGolang, scopeJavaScript, scopePython, scopeJava}
+
+	for _, group := range languageScopes {
+		for _, alias := range group {
+			if err := ValidateEnrich([]string{alias}); err != nil {
+				t.Errorf("alias %q is dispatchable but ValidateEnrich rejected it: %v", alias, err)
+			}
+			if cfg := buildSBOMConfig(SBOMOptions{Enrich: []string{alias}}); cfg == nil {
+				t.Errorf("alias %q passed validation but buildSBOMConfig returned nil", alias)
+			}
+		}
+	}
+
+	for scope := range unsupportedScopes {
+		if err := ValidateEnrich([]string{scope}); err == nil {
+			t.Errorf("scope %q is unsupported but ValidateEnrich accepted it", scope)
+		}
+		// Negation is the one accepted form, and it must not enable anything.
+		if err := ValidateEnrich([]string{"-" + scope}); err != nil {
+			t.Errorf("scope %q negated should be accepted, got: %v", scope, err)
+		}
+		if enrichmentScope([]string{"-" + scope}, scope) {
+			t.Errorf("scope %q negated must not enable anything", scope)
+		}
+	}
 }

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -77,6 +77,13 @@ func Command() *cobra.Command {
 				return ui.Error("--enrich requires network access and cannot be combined with --offline")
 			}
 
+			// Reject unrecognised scopes before cataloguing starts. An unknown
+			// scope is otherwise a silent no-op, which reads as success while
+			// producing an SBOM without the metadata the user opted in for.
+			if err := bill.ValidateEnrich(opts.Enrich); err != nil {
+				return ui.Error(err)
+			}
+
 			var sbm *sbom.SBOM
 			var inputRefs []bill.InputSbomRef
 			var purls []models.PurlDetail


### PR DESCRIPTION
## Problem

An unrecognised `--enrich` scope was a silent no-op. `enrichmentScope` simply never matches it, so:

```
$ vulncheck scan . --enrich pythonn
SBOM generation completed successfully
```

The command reports success and produces an SBOM with none of the metadata the user opted in for. There was no per-scope validation, so a typo was indistinguishable from a correct invocation.

## What this changes

`bill.ValidateEnrich` runs before any cataloguing starts, called from `scan.go` alongside the two existing `--enrich` guards:

```
--enrich rust           → ✗ unknown --enrich scope "rust"; supported scopes: all, golang, java, javascript, python
--enrich golang,pythonn → ✗ unknown --enrich scope "pythonn"; supported scopes: all, golang, java, javascript, python
--enrich golang,        → ✗ empty --enrich scope in ""; supported scopes: …
```

## vcpkg

syft 1.51 (#321) added `vcpkg` to its publicised enrichment scopes. This deliberately does **not** wire it up, and rejects it explicitly rather than leaving it as a silent no-op:

```
--enrich vcpkg → ✗ --enrich vcpkg is not supported by this CLI (syft accepts it, but it clones git
                   registries named in the scanned repository's own vcpkg.json). Packages declared in
                   vcpkg.json are still catalogued without it; run syft directly if you need registry
                   resolution. Supported scopes: all, golang, java, javascript, python
```

The reasoning: resolving vcpkg manifests clones git registries whose URLs are read from the scanned repository's own `vcpkg.json` (`resolver.go:333` upstream, reached via `default-registry` / `registries[]`). Every other scope fetches from a fixed endpoint — proxy.golang.org, Maven Central, npm, PyPI. This is the only one where **the scan target chooses where the CLI sends outbound requests**, which is a different risk shape from the rest and worth a deliberate decision rather than inheriting by parity.

Both names syft accepts for it (`vcpkg` and `cpp`) are rejected. Disabling it (`all,-vcpkg`) is *accepted* rather than rejected, since that asks for the behaviour we already have — erroring there would fail a command whose intent we satisfy.

This does not close the door on supporting vcpkg later; it makes today's behaviour honest.

## Structure

The scope alias lists are now shared vars used by **both** `buildSBOMConfig`'s dispatch and validation, so a scope cannot be dispatchable but unrecognised (or vice versa) as syft evolves. Verified against syft 1.51 that the five enrichment groups upstream — `cpp`/`vcpkg`, `go`/`golang`, `java`/`maven`, `javascript`/`node`/`npm`, `python` — are all accounted for.

Matching stays case-sensitive and `+`/`-` prefixes are still accepted, both for parity with syft's own exact-match comparison.

## Tests

- `TestValidateEnrich` — accepted scopes, aliases, prefixes, unknown scopes, typos, empty elements, vcpkg/cpp rejection, negation carve-out
- `TestValidateEnrichAgreesWithDispatch` — asserts the validation set and the dispatch table cannot drift apart
- `TestEnrichAllDoesNotEnableVcpkgCloning` — pins that `--enrich all` never flips `VcpkgAllowGitClone`, asserted against syft's config directly rather than our dispatch table, so a future syft bump that starts defaulting it on is caught here. Confirmed the assertion fails when cloning is wired on.

Full `go build ./...`, `go vet ./...` and `go test ./...` clean on top of syft 1.51.

## Note

`pkg/cmd/scan/scan.go` was already not gofmt-clean before this change (struct tag alignment in `scanEnvelope`, lines 27-30). Left alone to keep this diff focused — CI passes because golangci-lint isn't running the gofmt linter.