### PR TITLE
3491 vulncheck api token fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ completions: bin/vulncheck$(EXE)
 test:
 	go test ./...
 
-# Opt-in offline↔online parity suite. Needs VC_TOKEN and synced offline
+# Opt-in offline↔online parity suite. Needs VULNCHECK_API_TOKEN and synced offline
 # indices; the tests skip themselves if either is missing. See pkg/parity.
 .PHONY: test-parity
 test-parity:

--- a/README.md
+++ b/README.md
@@ -62,13 +62,16 @@ You should see the version, build date, and changelog URL. If you get "command n
 
 ## Configuration
 * Run `vulncheck auth login` to authenticate with your VulnCheck account.
-* Alternatively `vulncheck` will respect the `VC_TOKEN` environment variable.
+* Alternatively `vulncheck` will respect the `VULNCHECK_API_TOKEN` environment
+  variable — the same name used by the VulnCheck SDKs and MCP server. The
+  legacy `VC_TOKEN` also still works, and **takes precedence when both are
+  set**.
 * `vulncheck auth` by itself will show other options like checking your status and logging out.
 
-`VC_TOKEN` wins over the saved config file. Because of that, `auth login` and
-`auth logout` refuse while it is set — otherwise they would report success
-having changed nothing that takes effect. Run `vulncheck auth status` to see
-which of the two sources the active token came from.
+Either environment variable wins over the saved config file. Because of that,
+`auth login` and `auth logout` refuse while one is set — otherwise they would
+report success having changed nothing that takes effect. Run `vulncheck auth
+status` to see which source, and which variable, the active token came from.
 
 
 ## Agentic / scripted usage
@@ -88,7 +91,8 @@ The CLI is designed to be safe to drive from scripts and AI agents. This section
 
 | Variable                                   | Effect |
 |--------------------------------------------|--------|
-| `VC_TOKEN`                                 | API token. Takes precedence over `~/.config/vulncheck/vulncheck.yaml`. While it is set, `auth login` and `auth logout` refuse rather than writing a config file that would be ignored — `unset VC_TOKEN` first. |
+| `VULNCHECK_API_TOKEN`                      | API token, and the recommended name — shared with the VulnCheck SDKs and MCP server. Takes precedence over `~/.config/vulncheck/vulncheck.yaml`; while set, `auth login` and `auth logout` refuse rather than writing a file that would be ignored. |
+| `VC_TOKEN`                                 | Legacy alias, still fully supported and **taking precedence over `VULNCHECK_API_TOKEN` when both are set**, so no existing setup changes credential. Clear both to fall back to the config file. `auth status` reports which is in use. |
 | `NO_COLOR`                                 | Any non-empty value disables ANSI styling. |
 | `CI` / `BUILD_NUMBER` / `RUN_ID`           | Any of these set implies non-interactive mode (no prompts). |
 
@@ -121,7 +125,7 @@ In `--json` mode, errors are emitted to **stdout** as:
 }
 ```
 
-`code` is one of: `internal`, `validation`, `auth_required`, `auth_invalid`, `not_found`, `rate_limited`, `network`, `bad_request`, `cancelled`. `http_status` is omitted for non-HTTP errors. `hint` is optional remediation context — present only when the message alone isn't actionable (e.g. naming `VC_TOKEN` as the source of a rejected token) — and is rendered on stderr as `hint: ...` outside `--json` mode.
+`code` is one of: `internal`, `validation`, `auth_required`, `auth_invalid`, `not_found`, `rate_limited`, `network`, `bad_request`, `cancelled`. `http_status` is omitted for non-HTTP errors. `hint` is optional remediation context, present only when the message alone isn't actionable (e.g. naming the variable that supplied a rejected token). Rendered on stderr as `hint: ...` outside `--json` mode.
 
 ### Probe commands
 
@@ -132,12 +136,16 @@ vulncheck version --json
 # {"schema_version": 1, "version": "...", "build_date": "...", "changelog_url": "..."}
 
 vulncheck auth status --json
-# {"schema_version": 1, "authenticated": true, "token_source": "env", "user": "...", "email": "..."}
+# {"schema_version": 1, "authenticated": true, "token_source": "env",
+#  "token_env_var": "VC_TOKEN", "user": "...", "email": "..."}
 # Exit 0 even when authenticated=false — agents dispatch on the bool.
-# token_shadowed: true is added when VC_TOKEN is overriding a *different*
-# token saved in vulncheck.yaml — the usual cause of "I logged in but
-# nothing changed". Omitted otherwise, so the CI shape (VC_TOKEN only,
-# no config file) never reports shadowing.
+# token_env_var names which variable supplied the token when token_source is
+# "env"; omitted otherwise. Set when authenticated=false too, so a rejected
+# token can be traced to the variable holding it.
+# token_shadowed: true is added when an environment token is overriding a
+# *different* token saved in vulncheck.yaml — the usual cause of "I logged
+# in but nothing changed". Omitted otherwise, so the CI shape (env token
+# only, no config file) never reports shadowing.
 
 vulncheck commands
 # {"schema_version": 1, "root": {"name":"vulncheck", "subcommands":[...]}, ...}

--- a/cmd/vulncheck/contract_test.go
+++ b/cmd/vulncheck/contract_test.go
@@ -374,6 +374,23 @@ func authorizedAPI(t *testing.T) string {
 	return "VC_API=" + srv.URL
 }
 
+// authorizedAPIExpecting is authorizedAPI plus an assertion on the exact
+// Authorization header received. The permissive stub cannot tell a trimmed
+// token from a padded one: net/http refuses a header value containing a
+// newline outright, but a trailing space travels fine and the stub would
+// accept it. Proving the trim means looking at what went over the wire.
+func authorizedAPIExpecting(t *testing.T, wantToken string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if got := req.Header.Get("Authorization"); got != "Bearer "+wantToken {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer "+wantToken)
+		}
+		_, _ = w.Write([]byte(`{"data":{"Name":"Test User","Email":"test@example.com"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return "VC_API=" + srv.URL
+}
+
 // A stale VC_TOKEN silently overrode a saved token, so `auth login` verified
 // the pasted value, skipped the save, and still reported success. It must now
 // refuse rather than pretend.
@@ -633,5 +650,34 @@ func TestContractUnsetHintNamesAndExplainsBothVars(t *testing.T) {
 	// credential the SDK needs.
 	if strings.Contains(stderr, "would have no effect") && !strings.Contains(stderr, "nothing to do") {
 		t.Errorf("refusal must not read as a broken setup; got %q", stderr)
+	}
+}
+
+// A token carrying a trailing newline used to reach net/http, which refuses
+// the Authorization header — surfacing as code "internal" (exit 1) naming no
+// variable, so an agent branching on the auth codes treated a fixable
+// credential problem as a CLI bug. A trailing space was worse: it survives
+// the header and comes back as a bare 401 on a perfectly good token.
+func TestContractWhitespacePaddedTokenIsUsable(t *testing.T) {
+	for _, tt := range []struct{ name, padded string }{
+		{"trailing newline", "vulncheck_api_token_value\n"},
+		{"surrounding spaces", "  vulncheck_api_token_value  "},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, _, exit := runCLIHomeEnv(t, t.TempDir(),
+				[]string{
+					"VULNCHECK_API_TOKEN=" + tt.padded,
+					authorizedAPIExpecting(t, "vulncheck_api_token_value"),
+				},
+				"", "auth", "status", "--json")
+			if exit != 0 {
+				t.Fatalf("exit = %d, want 0", exit)
+			}
+			m := mustJSON(t, stdout)
+			if m["authenticated"] != true {
+				t.Errorf("authenticated = %v, want true (padding should be trimmed); got %v",
+					m["authenticated"], m)
+			}
+		})
 	}
 }

--- a/cmd/vulncheck/contract_test.go
+++ b/cmd/vulncheck/contract_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -70,6 +72,14 @@ func runCLIEnv(t *testing.T, token string, args ...string) (stdout, stderr strin
 // their own vulncheck.yaml without disturbing the package-wide isolatedHome.
 func runCLIHome(t *testing.T, home, token string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
+	return runCLIHomeEnv(t, home, nil, token, args...)
+}
+
+// runCLIHomeEnv is runCLIHome with extra environment entries appended after
+// the fixture, so a test can point the CLI at a stub API. Later entries win,
+// so extra overrides the defaults below.
+func runCLIHomeEnv(t *testing.T, home string, extra []string, token string, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
 	cmd := exec.Command(binPath, args...)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -88,6 +98,7 @@ func runCLIHome(t *testing.T, home, token string, args ...string) (stdout, stder
 		"BUILD_NUMBER=",
 		"RUN_ID=",
 	)
+	cmd.Env = append(cmd.Env, extra...)
 	_ = cmd.Run()
 	return outBuf.String(), errBuf.String(), cmd.ProcessState.ExitCode()
 }
@@ -330,6 +341,21 @@ func homeWithToken(t *testing.T, token string) string {
 	return home
 }
 
+// unauthorizedAPI starts a stub API that rejects every request and returns the
+// VC_API entry pointing the CLI at it. Any test whose fixture token reaches a
+// *verification* call needs this: the tokens are syntactically valid, so the
+// 401 has to come from a server, and without the override that server is
+// production.
+func unauthorizedAPI(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"unauthorized"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return "VC_API=" + srv.URL
+}
+
 // A stale VC_TOKEN silently overrode a saved token, so `auth login` verified
 // the pasted value, skipped the save, and still reported success. It must now
 // refuse rather than pretend.
@@ -387,7 +413,8 @@ func TestContractAuthLogoutRefusesWhenEnvTokenSet(t *testing.T) {
 func TestContractAuthStatusReportsShadowing(t *testing.T) {
 	home := homeWithToken(t, "vulncheck_saved_token_value")
 
-	stdout, _, exit := runCLIHome(t, home, "vulncheck_env_token_value", "auth", "status", "--json")
+	stdout, _, exit := runCLIHomeEnv(t, home, []string{unauthorizedAPI(t)},
+		"vulncheck_env_token_value", "auth", "status", "--json")
 	if exit != 0 {
 		t.Fatalf("exit = %d, want 0", exit)
 	}
@@ -403,7 +430,8 @@ func TestContractAuthStatusReportsShadowing(t *testing.T) {
 // token_shadowed must stay absent when only VC_TOKEN is set — that is the
 // normal CI shape and it must not look like a misconfiguration.
 func TestContractAuthStatusNoShadowingInCIShape(t *testing.T) {
-	stdout, _, exit := runCLIHome(t, t.TempDir(), "vulncheck_env_token_value", "auth", "status", "--json")
+	stdout, _, exit := runCLIHomeEnv(t, t.TempDir(), []string{unauthorizedAPI(t)},
+		"vulncheck_env_token_value", "auth", "status", "--json")
 	if exit != 0 {
 		t.Fatalf("exit = %d, want 0", exit)
 	}

--- a/cmd/vulncheck/contract_test.go
+++ b/cmd/vulncheck/contract_test.go
@@ -681,3 +681,20 @@ func TestContractWhitespacePaddedTokenIsUsable(t *testing.T) {
 		})
 	}
 }
+
+// The GitHub Actions help is the one place the CLI hands the user a snippet to
+// paste. Naming only VULNCHECK_API_TOKEN sends anyone holding the VC_TOKEN
+// secret that vulncheck-oss/action documents into a dead end: a missing secret
+// expands to an empty string, so they land right back on "No token found".
+func TestContractGitHubActionsHelpNamesBothSecrets(t *testing.T) {
+	_, stderr, exit := runCLIHomeEnv(t, t.TempDir(),
+		[]string{"GITHUB_ACTIONS=true"}, "", "indices", "list")
+	if exit != 3 {
+		t.Fatalf("exit = %d, want 3 (auth)", exit)
+	}
+	for _, want := range []string{"VULNCHECK_API_TOKEN", "VC_TOKEN"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("Actions help must name %s; got %q", want, stderr)
+		}
+	}
+}

--- a/cmd/vulncheck/contract_test.go
+++ b/cmd/vulncheck/contract_test.go
@@ -51,8 +51,8 @@ func TestMain(m *testing.M) {
 }
 
 // runCLI shells out to the built binary with the given args and returns
-// stdout, stderr, and the process exit code. VC_TOKEN is force-cleared
-// so tests that assert auth-required paths behave consistently.
+// stdout, stderr, and the process exit code. Both token variables are
+// force-cleared so tests that assert auth-required paths behave consistently.
 func runCLI(t *testing.T, args ...string) (stdout, stderr string, exitCode int) {
 	return runCLIEnv(t, "", args...)
 }
@@ -76,8 +76,8 @@ func runCLIHome(t *testing.T, home, token string, args ...string) (stdout, stder
 }
 
 // runCLIHomeEnv is runCLIHome with extra environment entries appended after
-// the fixture, so a test can point the CLI at a stub API. Later entries win,
-// so extra overrides the defaults below.
+// the fixture, so a test can set both token variables at once. Later entries
+// win, so extra overrides the defaults below.
 func runCLIHomeEnv(t *testing.T, home string, extra []string, token string, args ...string) (stdout, stderr string, exitCode int) {
 	t.Helper()
 	cmd := exec.Command(binPath, args...)
@@ -92,6 +92,11 @@ func runCLIHomeEnv(t *testing.T, home string, extra []string, token string, args
 		"USERPROFILE="+home,
 		"XDG_CONFIG_HOME="+home,
 		"VC_TOKEN="+token,
+		// runCLI passes token == "", which falls through to the next variable:
+		// without this a developer with VULNCHECK_API_TOKEN exported has their
+		// real token satisfy every auth-required test. CI never exports one,
+		// so it presents as developer-machine-only flakiness.
+		"VULNCHECK_API_TOKEN=",
 		"NO_COLOR=1",
 		// Clear CI so Interactive() logic isn't skewed by the outer test env.
 		"CI=",
@@ -323,10 +328,11 @@ func TestContractScanSbomOnlyJSON(t *testing.T) {
 	}
 }
 
-// ----- VC_TOKEN shadowing guardrail -----
+// ----- environment token guardrails -----
 
 // homeWithToken returns a fresh HOME containing a vulncheck.yaml that holds
-// the given token, so tests can create the "logged in AND VC_TOKEN set" state.
+// the given token, so tests can create the "logged in AND an environment
+// token set" state.
 func homeWithToken(t *testing.T, token string) string {
 	t.Helper()
 	home := t.TempDir()
@@ -356,6 +362,18 @@ func unauthorizedAPI(t *testing.T) string {
 	return "VC_API=" + srv.URL
 }
 
+// authorizedAPI starts a stub API that accepts every request with a /me
+// payload, and returns the VC_API entry pointing the CLI at it. Needed by the
+// tests that assert on *successful* auth output.
+func authorizedAPI(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"Name":"Test User","Email":"test@example.com"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return "VC_API=" + srv.URL
+}
+
 // A stale VC_TOKEN silently overrode a saved token, so `auth login` verified
 // the pasted value, skipped the save, and still reported success. It must now
 // refuse rather than pretend.
@@ -371,8 +389,8 @@ func TestContractAuthLoginRefusesWhenEnvTokenSet(t *testing.T) {
 	if !strings.Contains(stderr, "VC_TOKEN") {
 		t.Errorf("stderr should name VC_TOKEN as the cause; got %q", stderr)
 	}
-	if !strings.Contains(stderr, "unset") {
-		t.Errorf("stderr should tell the user to unset VC_TOKEN; got %q", stderr)
+	if !strings.Contains(stderr, "clear VC_TOKEN from your environment") {
+		t.Errorf("stderr should tell the user how to stop VC_TOKEN winning; got %q", stderr)
 	}
 
 	// The saved token must be untouched — refusing is not a licence to write.
@@ -425,6 +443,75 @@ func TestContractAuthStatusReportsShadowing(t *testing.T) {
 	if v, _ := m["token_shadowed"].(bool); !v {
 		t.Errorf("token_shadowed = %v, want true", m["token_shadowed"])
 	}
+	if m["token_env_var"] != "VC_TOKEN" {
+		t.Errorf("token_env_var = %v, want VC_TOKEN", m["token_env_var"])
+	}
+}
+
+// The CLI must accept VULNCHECK_API_TOKEN and report which variable it read.
+// Runs through the verify-failed branch, where naming it matters most.
+func TestContractAuthStatusAcceptsDocumentedEnvVar(t *testing.T) {
+	stdout, _, exit := runCLIHomeEnv(t, t.TempDir(),
+		[]string{"VULNCHECK_API_TOKEN=vulncheck_api_token_value", unauthorizedAPI(t)},
+		"", "auth", "status", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	m := mustJSON(t, stdout)
+	if m["token_source"] != "env" {
+		t.Errorf("token_source = %v, want env", m["token_source"])
+	}
+	if m["token_env_var"] != "VULNCHECK_API_TOKEN" {
+		t.Errorf("token_env_var = %v, want VULNCHECK_API_TOKEN", m["token_env_var"])
+	}
+}
+
+// VC_TOKEN keeps winning, so no existing setup silently changes which
+// credential it authenticates with when VULNCHECK_API_TOKEN is also present.
+func TestContractLegacyEnvVarTakesPrecedence(t *testing.T) {
+	stdout, _, exit := runCLIHomeEnv(t, t.TempDir(),
+		[]string{"VULNCHECK_API_TOKEN=vulncheck_api_token_value", unauthorizedAPI(t)},
+		"vulncheck_env_token_value", "auth", "status", "--json")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if m := mustJSON(t, stdout); m["token_env_var"] != "VC_TOKEN" {
+		t.Errorf("token_env_var = %v, want VC_TOKEN (legacy must keep winning)", m["token_env_var"])
+	}
+}
+
+// Refusals must name the variable actually in use, not a hardcoded VC_TOKEN:
+// advice to clear VC_TOKEN would leave a VULNCHECK_API_TOKEN user just as stuck.
+func TestContractAuthLoginRefusalNamesDocumentedEnvVar(t *testing.T) {
+	home := homeWithToken(t, "vulncheck_saved_token_value")
+
+	_, stderr, exit := runCLIHomeEnv(t, home,
+		[]string{"VULNCHECK_API_TOKEN=vulncheck_api_token_value"},
+		"", "auth", "login", "token")
+	if exit != 2 {
+		t.Fatalf("exit = %d, want 2 (validation)\nstderr: %s", exit, stderr)
+	}
+	if !strings.Contains(stderr, "clear VULNCHECK_API_TOKEN from your environment") {
+		t.Errorf("hint must name the variable in use; got %q", stderr)
+	}
+}
+
+// With both variables set, a hint naming only the winner sends the user in a
+// loop: clearing VC_TOKEN hands the win to VULNCHECK_API_TOKEN and the next
+// attempt is refused all over again. Assert the joined form specifically — a
+// test that merely looked for "VC_TOKEN" would pass against that bug.
+func TestContractAuthLoginHintNamesEveryEnvToken(t *testing.T) {
+	home := homeWithToken(t, "vulncheck_saved_token_value")
+
+	_, stderr, exit := runCLIHomeEnv(t, home,
+		[]string{"VULNCHECK_API_TOKEN=vulncheck_api_token_value"},
+		"vulncheck_env_token_value", "auth", "login", "token")
+	if exit != 2 {
+		t.Fatalf("exit = %d, want 2 (validation)\nstderr: %s", exit, stderr)
+	}
+	if !strings.Contains(stderr, "clear VC_TOKEN and VULNCHECK_API_TOKEN from your environment") {
+		t.Errorf("hint must name both variables at once; got %q", stderr)
+	}
 }
 
 // token_shadowed must stay absent when only VC_TOKEN is set — that is the
@@ -445,7 +532,10 @@ func TestContractAuthStatusNoShadowingInCIShape(t *testing.T) {
 // "re-login changes nothing" loop is self-diagnosing.
 func TestContractAuthErrorEnvelopeHint(t *testing.T) {
 	// No token anywhere: no source to name, so no hint.
-	stdout, _, _ := runCLIHome(t, t.TempDir(), "", "indices", "list", "--json")
+	stdout, _, exit := runCLIHome(t, t.TempDir(), "", "indices", "list", "--json")
+	if exit != 3 {
+		t.Errorf("exit = %d, want 3 (auth)", exit)
+	}
 	m := mustJSON(t, stdout)
 	errObj, ok := m["error"].(map[string]any)
 	if !ok {
@@ -453,5 +543,95 @@ func TestContractAuthErrorEnvelopeHint(t *testing.T) {
 	}
 	if _, present := errObj["hint"]; present {
 		t.Errorf("hint should be omitted when there is no token source to name; got %v", errObj)
+	}
+}
+
+// The auth_required hint must name whichever variable supplied the rejected
+// token, so a user who exported only the documented name is not sent looking
+// for a VC_TOKEN they never set.
+func TestContractAuthErrorEnvelopeNamesDocumentedEnvVar(t *testing.T) {
+	stdout, _, exit := runCLIHomeEnv(t, t.TempDir(),
+		[]string{"VULNCHECK_API_TOKEN=vulncheck_api_token_value", unauthorizedAPI(t)},
+		"", "indices", "list", "--json")
+
+	// The exit code is what an agent branches on before it ever parses the
+	// envelope; a rejected token must not arrive as a generic failure.
+	if exit != 3 {
+		t.Errorf("exit = %d, want 3 (auth)", exit)
+	}
+	m := mustJSON(t, stdout)
+	errObj, ok := m["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected an error envelope, got %v", m)
+	}
+	if errObj["code"] != "auth_invalid" {
+		t.Errorf("code = %v, want auth_invalid", errObj["code"])
+	}
+	hint, _ := errObj["hint"].(string)
+	if !strings.Contains(hint, "VULNCHECK_API_TOKEN") {
+		t.Errorf("hint should name the variable the token came from; got %q", hint)
+	}
+	// No config file was written here, so a hint contrasting the environment
+	// with one sends the user looking for a file that does not exist.
+	if strings.Contains(hint, "config file") {
+		t.Errorf("hint must not point at a config file that was never written; got %q", hint)
+	}
+}
+
+// ----- both token variables set -----
+
+// The two-variable state is reported by the unset command naming both, never
+// by prose about the variable that lost. Prose would have to know which won,
+// whether the other differs, whether a config file exists and whether that
+// differs — a state space that produced a false "is being ignored" warning for
+// the one setup this fallback exists to serve: a single credential exported
+// under both names to feed the CLI and an SDK.
+func TestContractBothEnvVarsSetStayQuiet(t *testing.T) {
+	for _, tt := range []struct{ name, documented string }{
+		{"identical tokens", "vulncheck_legacy_token"},
+		{"differing tokens", "vulncheck_documented_token"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, exit := runCLIHomeEnv(t, t.TempDir(),
+				[]string{"VULNCHECK_API_TOKEN=" + tt.documented, authorizedAPI(t)},
+				"vulncheck_legacy_token", "auth", "status", "--json")
+			if exit != 0 {
+				t.Fatalf("exit = %d, want 0\nstderr: %s", exit, stderr)
+			}
+			m := mustJSON(t, stdout)
+			// The variable in use is named; the one that lost is not a field.
+			if m["token_env_var"] != "VC_TOKEN" {
+				t.Errorf("token_env_var = %v, want VC_TOKEN", m["token_env_var"])
+			}
+			for _, gone := range []string{"token_env_var_ignored", "token_env_var_conflict"} {
+				if _, present := m[gone]; present {
+					t.Errorf("%s must not be part of the contract; got %v", gone, m)
+				}
+			}
+			if strings.Contains(stderr, "ignored") {
+				t.Errorf("no prose about the losing variable; got %q", stderr)
+			}
+		})
+	}
+}
+
+// With both variables set, the remediation has to clear both — clearing only
+// the winner hands the win to the other and refuses the next attempt all over
+// again. The command therefore names a variable the sentence does not, so it
+// has to say why, or it reads as the CLI having picked the wrong variable.
+func TestContractUnsetHintNamesAndExplainsBothVars(t *testing.T) {
+	_, stderr, exit := runCLIHomeEnv(t, t.TempDir(),
+		[]string{"VULNCHECK_API_TOKEN=vulncheck_documented_token", authorizedAPI(t)},
+		"vulncheck_legacy_token", "auth", "login", "token", "vulncheck_pasted_token")
+	if exit != 2 {
+		t.Fatalf("exit = %d, want 2 (validation)", exit)
+	}
+	if !strings.Contains(stderr, "clear VC_TOKEN and VULNCHECK_API_TOKEN from your environment") {
+		t.Errorf("hint must name both variables at once; got %q", stderr)
+	}
+	// A working SDK setup is not a failure to be fixed by deleting the
+	// credential the SDK needs.
+	if strings.Contains(stderr, "would have no effect") && !strings.Contains(stderr, "nothing to do") {
+		t.Errorf("refusal must not read as a broken setup; got %q", stderr)
 	}
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -27,12 +27,15 @@ func Command() *cobra.Command {
 		Example: i18n.C.AuthLoginExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := output.FromCmd(cmd)
-			if !r.Interactive() {
-				return errs.Validation("%s", i18n.C.AuthLoginErrorCI)
-			}
-
+			// Before the interactivity check: in CI with a token already
+			// exported, AuthLoginErrorCI advises setting the variable that is
+			// set, where GuardEnvToken says the CLI already uses it.
 			if err := pkgLogin.GuardEnvToken(); err != nil {
 				return err
+			}
+
+			if !r.Interactive() {
+				return errs.Validation("%s", i18n.C.AuthLoginErrorCI)
 			}
 
 			if config.HasConfig() && config.HasToken() {

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -19,23 +19,24 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			res := config.Resolve()
 
-			// Logout can only clear the config file. When VC_TOKEN supplies the
-			// active token, proceeding would revoke the *environment* token
-			// server-side (config.Token() returns it) while deleting a
-			// different token from disk, then report success even though
-			// CheckAuth still passes off the env var. Refuse instead.
+			// Logout can only clear the config file. When a token environment
+			// variable supplies the active token, proceeding would revoke the
+			// *environment* token server-side (config.Token() returns it)
+			// while deleting a different token from disk, then report success
+			// even though CheckAuth still passes off the env var. Refuse
+			// instead.
 			if res.FromEnv() {
 				e := errs.Validation(
 					"%s is set; `auth logout` cannot unset an environment variable",
-					config.EnvToken)
+					res.EnvVar)
 				if res.Shadowed {
 					return e.WithHint(
-						"run `unset %s`, then `vulncheck auth logout` again to revoke and remove the token saved in your config file.",
-						config.EnvToken)
+						"to revoke and remove the token saved in your config file, %s, then run `vulncheck auth logout` again.",
+						res.UnsetHint())
 				}
 				return e.WithHint(
-					"run `unset %s` to stop using it, and revoke it with `vulncheck token remove <id>` if it should no longer work.",
-					config.EnvToken)
+					"to stop using it, %s; revoke it with `vulncheck token remove <id>` if it should no longer work.",
+					res.UnsetHint())
 			}
 
 			if res.ConfigToken == "" {

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -24,9 +24,12 @@ type authStatus struct {
 	SchemaVersion int    `json:"schema_version"`
 	Authenticated bool   `json:"authenticated"`
 	TokenSource   string `json:"token_source,omitempty"` // "env" | "config" | ""
-	// TokenShadowed reports that VC_TOKEN is overriding a different token
-	// saved in the config file. Agents can key off this to explain why a
-	// freshly saved credential appears to have no effect.
+	// TokenEnvVar names the variable that supplied the token when TokenSource
+	// is "env". Additive: callers that only know token_source keep working.
+	TokenEnvVar string `json:"token_env_var,omitempty"` // "VC_TOKEN" | "VULNCHECK_API_TOKEN"
+	// TokenShadowed reports that a token environment variable is overriding a
+	// different token saved in the config file. Agents can key off this to
+	// explain why a freshly saved credential appears to have no effect.
 	TokenShadowed bool   `json:"token_shadowed,omitempty"`
 	User          string `json:"user,omitempty"`
 	Email         string `json:"email,omitempty"`
@@ -37,7 +40,7 @@ type authStatus struct {
 // naming the concrete location so the user knows where to go and change it.
 func tokenSourceLabel(res config.Resolution) string {
 	if res.FromEnv() {
-		return config.EnvToken + " environment variable"
+		return res.EnvVar + " environment variable"
 	}
 	if dir, err := config.Dir(); err == nil {
 		return dir + "/vulncheck.yaml"
@@ -80,6 +83,7 @@ func Command() *cobra.Command {
 					s := newAuthStatus()
 					s.Authenticated = false
 					s.TokenSource = string(res.Source)
+					s.TokenEnvVar = res.EnvVar
 					s.TokenShadowed = res.Shadowed
 					s.Reason = reason
 					return r.JSON(s)
@@ -91,20 +95,19 @@ func Command() *cobra.Command {
 				s := newAuthStatus()
 				s.Authenticated = true
 				s.TokenSource = string(res.Source)
+				s.TokenEnvVar = res.EnvVar
 				s.TokenShadowed = res.Shadowed
 				s.User = resp.Data.Name
 				s.Email = resp.Data.Email
 				return r.JSON(s)
 			}
 
-			// Human output: name the source explicitly. Which of the two
-			// places the token came from is the single most useful fact when
-			// an unexpected account or a stale credential is in play, and it
-			// was previously only visible via --json.
+			// The most useful fact when an unexpected account is in play.
 			r.Stat("Token source", tokenSourceLabel(res))
+			// Reported, not instructed: nothing failed, and an environment
+			// token winning is usually deliberate.
 			if res.Shadowed {
-				r.Warn("%s is overriding a different token saved in your config file; run `unset %s` to use the saved one.",
-					config.EnvToken, config.EnvToken)
+				r.Warn("%s is overriding a different token saved in your config file.", res.EnvVar)
 			}
 
 			return login.SaveToken(res.Token)

--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -8,20 +8,22 @@ import (
 func authHelp() string {
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
 		return heredoc.Doc(`
-			vulncheck: To use VulnCheck CLI in a GitHub Actions workflow, set the VC_TOKEN environment variable. Example:
+			vulncheck: To use VulnCheck CLI in a GitHub Actions workflow, set the VULNCHECK_API_TOKEN environment variable. Example:
 			  env:
-			    VC_TOKEN: ${{ secrets.VC_TOKEN }}
+			    VULNCHECK_API_TOKEN: ${{ secrets.VULNCHECK_API_TOKEN }}
+			Substitute your own secret name; vulncheck-oss/action uses VC_TOKEN, which is also still accepted.
+			Note that a secret that does not exist expands to an empty string, which reads here as no token at all.
 		`)
 	}
 
 	if os.Getenv("CI") != "" {
 		return heredoc.Doc(`
-			vulncheck: To use VulnCheck CLI in automation, set the VC_TOKEN environment variable.
+			vulncheck: To use VulnCheck CLI in automation, set the VULNCHECK_API_TOKEN environment variable.
 		`)
 	}
 
 	return heredoc.Doc(`
 		To get started with VulnCheck CLI, please run: vulncheck auth login
-		Alternatively, populate the VC_TOKEN environment variable with a VulnCheck token acquired from the portal at https://console.vulncheck.com/token.
+		Alternatively, populate the VULNCHECK_API_TOKEN environment variable with a VulnCheck token acquired from the portal at https://console.vulncheck.com/token.
 	`)
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -166,10 +166,10 @@ type errorBody struct {
 }
 
 // authHint explains which token source produced the credential that just
-// failed. Without this, a user with a stale VC_TOKEN shadowing a freshly
-// saved config token sees "unauthorized", re-runs `auth login`, is told it
-// succeeded, and hits the same error forever — the CLI never mentions that
-// the token in play came from the environment.
+// failed. Without this, a user with a stale environment token shadowing a
+// freshly saved config token sees "unauthorized", re-runs `auth login`, is
+// told it succeeded, and hits the same error forever — the CLI never mentions
+// that the token in play came from the environment.
 func authHint(kind errs.Kind) string {
 	if kind != errs.KindAuthInvalid && kind != errs.KindAuthRequired {
 		return ""
@@ -178,10 +178,14 @@ func authHint(kind errs.Kind) string {
 	switch {
 	case res.Shadowed:
 		return fmt.Sprintf(
-			"the token in use came from %s, which overrides the different token saved in your config file. Run `unset %s` to use the saved one.",
-			config.EnvToken, config.EnvToken)
+			"the token in use came from %s, which overrides the different token saved in your config file. To use the saved one, %s.",
+			res.EnvVar, res.UnsetHint())
+	case res.FromEnv() && res.ConfigToken != "":
+		return fmt.Sprintf("the token in use came from %s, not your config file.", res.EnvVar)
 	case res.FromEnv():
-		return fmt.Sprintf("the token in use came from %s, not your config file.", config.EnvToken)
+		// No config file to contrast with — saying "not your config file"
+		// here sends the user looking for one that was never written.
+		return fmt.Sprintf("the token in use came from %s.", res.EnvVar)
 	default:
 		return ""
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,8 +136,12 @@ func HasConfig() bool {
 	return err == nil
 }
 
-// EnvToken is the environment variable consulted before the config file.
+// EnvToken is the legacy token variable, consulted first. See Resolve.
 const EnvToken = "VC_TOKEN"
+
+// EnvTokenAPI is the name shared with the VulnCheck SDKs and MCP server, and the
+// one user-facing copy should teach. EnvToken keeps precedence over it.
+const EnvTokenAPI = "VULNCHECK_API_TOKEN"
 
 // TokenSource identifies where the active token came from. The string values
 // are the agent-facing contract emitted by `auth status --json`.
@@ -146,7 +150,8 @@ type TokenSource string
 const (
 	// SourceNone means no usable token was found in either location.
 	SourceNone TokenSource = ""
-	// SourceEnv means the token came from the VC_TOKEN environment variable.
+	// SourceEnv means the token came from one of the token environment
+	// variables; Resolution.EnvVar reports which.
 	SourceEnv TokenSource = "env"
 	// SourceConfig means the token came from vulncheck.yaml.
 	SourceConfig TokenSource = "config"
@@ -160,23 +165,46 @@ type Resolution struct {
 	Token string
 	// Source says which location Token came from.
 	Source TokenSource
-	// Shadowed reports that VC_TOKEN is overriding a *different* token saved
-	// in vulncheck.yaml. Only true when both are present and their values
-	// differ — identical values cannot confuse anyone, and CI (env set, no
-	// config file) is never shadowed, so this stays quiet in automation.
+	// Shadowed reports that a token environment variable is overriding a
+	// *different* token saved in vulncheck.yaml. Only true when both are
+	// present and their values differ — identical values cannot confuse
+	// anyone, and CI (env set, no config file) is never shadowed, so this
+	// stays quiet in automation.
 	Shadowed bool
 	// ConfigToken is the token stored in vulncheck.yaml, whether or not it
 	// won. Used to report shadowing; never render it to the user.
 	ConfigToken string
+	// EnvVar names the variable Token came from, or "" when Source is not
+	// SourceEnv. Messages must use this rather than a fixed constant, or they
+	// will name the wrong variable to half the users who see them.
+	EnvVar string
+	// EnvVarsSet names every token variable holding a usable value, in
+	// precedence order; EnvVarsSet[0] == EnvVar. Hints must clear all of them —
+	// clearing only the winner hands the win to the next.
+	EnvVarsSet []string
 }
 
 // FromEnv reports whether the active token came from the environment.
 func (r Resolution) FromEnv() bool { return r.Source == SourceEnv }
 
-// Resolve determines the active token. Precedence: VC_TOKEN, then the
-// token in vulncheck.yaml. A value that fails ValidToken is treated as absent
-// in both positions, so a blank or whitespace entry in either place falls
-// through to the next source rather than being sent to the API.
+// UnsetHint names every variable to clear, as an embeddable fragment. Shell
+// neutral: `unset` is not a command on Windows, which the CLI ships binaries for.
+func (r Resolution) UnsetHint() string {
+	switch n := len(r.EnvVarsSet); n {
+	case 0:
+		return ""
+	case 1:
+		return "clear " + r.EnvVarsSet[0] + " from your environment"
+	default:
+		return "clear " + strings.Join(r.EnvVarsSet[:n-1], ", ") +
+			" and " + r.EnvVarsSet[n-1] + " from your environment"
+	}
+}
+
+// Resolve determines the active token. Precedence: EnvToken, EnvTokenAPI, then
+// vulncheck.yaml; a value failing ValidToken is absent in every position.
+// The only place the CLI reads a token environment variable. Reading one
+// elsewhere duplicates the ValidToken rule and the precedence order.
 func Resolve() Resolution {
 	var res Resolution
 
@@ -184,10 +212,20 @@ func Resolve() Resolution {
 		res.ConfigToken = config.Token
 	}
 
-	if env := os.Getenv(EnvToken); ValidToken(env) {
-		res.Token = env
-		res.Source = SourceEnv
+	// Keep scanning past the winner — see EnvVarsSet.
+	for _, name := range []string{EnvToken, EnvTokenAPI} {
+		env := os.Getenv(name)
+		if !ValidToken(env) {
+			continue
+		}
+		res.EnvVarsSet = append(res.EnvVarsSet, name)
+		if res.Source == SourceEnv {
+			continue
+		}
+		res.Token, res.Source, res.EnvVar = env, SourceEnv, name
 		res.Shadowed = res.ConfigToken != "" && res.ConfigToken != env
+	}
+	if res.Source == SourceEnv {
 		return res
 	}
 
@@ -216,8 +254,9 @@ func SaveToken(token string) error {
 }
 
 // RemoveToken clears the saved token, preserving every other setting.
-// Note this only clears the *config file*; if VC_TOKEN is set the caller
-// remains authenticated. Check Resolve().FromEnv() before claiming otherwise.
+// Note this only clears the *config file*; if a token environment variable is
+// set the caller remains authenticated. Check Resolve().FromEnv() before
+// claiming otherwise.
 func RemoveToken() error {
 	return mutateConfig(func(c *Config) { c.Token = "" })
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -203,18 +203,21 @@ func (r Resolution) UnsetHint() string {
 
 // Resolve determines the active token. Precedence: EnvToken, EnvTokenAPI, then
 // vulncheck.yaml; a value failing ValidToken is absent in every position.
+// Values are trimmed as captured — net/http rejects an Authorization header
+// containing a newline, and a trailing space returns a plain 401.
+//
 // The only place the CLI reads a token environment variable. Reading one
 // elsewhere duplicates the ValidToken rule and the precedence order.
 func Resolve() Resolution {
 	var res Resolution
 
 	if config, err := loadConfig(); err == nil && ValidToken(config.Token) {
-		res.ConfigToken = config.Token
+		res.ConfigToken = strings.TrimSpace(config.Token)
 	}
 
 	// Keep scanning past the winner — see EnvVarsSet.
 	for _, name := range []string{EnvToken, EnvTokenAPI} {
-		env := os.Getenv(name)
+		env := strings.TrimSpace(os.Getenv(name))
 		if !ValidToken(env) {
 			continue
 		}
@@ -249,8 +252,9 @@ func HasToken() bool {
 }
 
 // SaveToken writes token to vulncheck.yaml, preserving every other setting.
+// Trimmed first: a padded paste saved verbatim fails every later run.
 func SaveToken(token string) error {
-	return mutateConfig(func(c *Config) { c.Token = token })
+	return mutateConfig(func(c *Config) { c.Token = strings.TrimSpace(token) })
 }
 
 // RemoveToken clears the saved token, preserving every other setting.

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -36,18 +38,71 @@ func writeConfigToken(t *testing.T, token string) {
 
 func TestResolvePrecedence(t *testing.T) {
 	tests := []struct {
-		name         string
-		env          string
-		configToken  string
-		wantToken    string
-		wantSource   TokenSource
-		wantShadowed bool
+		name        string
+		legacy      string // VC_TOKEN
+		documented  string // VULNCHECK_API_TOKEN
+		configToken string
+
+		wantToken      string
+		wantSource     TokenSource
+		wantShadowed   bool
+		wantEnvVar     string
+		wantUnsetsBoth bool // UnsetTargets must name both variables
 	}{
 		{
-			name:       "env only",
-			env:        "env_token",
+			name:       "legacy only",
+			legacy:     "env_token",
 			wantToken:  "env_token",
 			wantSource: SourceEnv,
+			wantEnvVar: EnvToken,
+		},
+		{
+			name:       "documented only",
+			documented: "api_token",
+			wantToken:  "api_token",
+			wantSource: SourceEnv,
+			wantEnvVar: EnvTokenAPI,
+		},
+		{
+			// The design decision: the documented name is a fallback, so no
+			// existing setup silently changes which credential it uses.
+			name:       "legacy wins over documented",
+			legacy:     "env_token",
+			documented: "api_token",
+			wantToken:  "env_token",
+			wantSource: SourceEnv,
+			wantEnvVar: EnvToken,
+			// Unsetting only the winner hands the win to the other one.
+			wantUnsetsBoth: true,
+		},
+		{
+			// Same value, but unsetting one still leaves the other winning,
+			// so the hint must clear both here too.
+			name:           "both set to the same value",
+			legacy:         "same_token",
+			documented:     "same_token",
+			wantToken:      "same_token",
+			wantSource:     SourceEnv,
+			wantEnvVar:     EnvToken,
+			wantUnsetsBoth: true,
+		},
+		{
+			// A whitespace-only value was never going to be sent, so it must
+			// stay out of the unset hint.
+			name:       "whitespace documented beside a valid legacy",
+			legacy:     "env_token",
+			documented: "   ",
+			wantToken:  "env_token",
+			wantSource: SourceEnv,
+			wantEnvVar: EnvToken,
+		},
+		{
+			name:       "blank legacy falls through to documented",
+			legacy:     "   ",
+			documented: "api_token",
+			wantToken:  "api_token",
+			wantSource: SourceEnv,
+			wantEnvVar: EnvTokenAPI,
 		},
 		{
 			name:        "config only",
@@ -56,21 +111,47 @@ func TestResolvePrecedence(t *testing.T) {
 			wantSource:  SourceConfig,
 		},
 		{
-			name:         "env shadows a different config token",
-			env:          "env_token",
+			name:         "legacy shadows a different config token",
+			legacy:       "env_token",
 			configToken:  "file_token",
 			wantToken:    "env_token",
 			wantSource:   SourceEnv,
 			wantShadowed: true,
+			wantEnvVar:   EnvToken,
+		},
+		{
+			name:         "documented shadows a different config token",
+			documented:   "api_token",
+			configToken:  "file_token",
+			wantToken:    "api_token",
+			wantSource:   SourceEnv,
+			wantShadowed: true,
+			wantEnvVar:   EnvTokenAPI,
+		},
+		{
+			// The state UnsetTargets was written for: both variables set
+			// *and* a different token in the config file. Clearing only the
+			// winner hands the win to the other variable, so the hint has to
+			// name both while still reporting the config file as shadowed.
+			name:           "both env vars set beside a differing config token",
+			legacy:         "env_token",
+			documented:     "api_token",
+			configToken:    "file_token",
+			wantToken:      "env_token",
+			wantSource:     SourceEnv,
+			wantShadowed:   true,
+			wantEnvVar:     EnvToken,
+			wantUnsetsBoth: true,
 		},
 		{
 			name:        "identical values are not shadowing",
-			env:         "same_token",
+			legacy:      "same_token",
 			configToken: "same_token",
 			wantToken:   "same_token",
 			wantSource:  SourceEnv,
 			// No possible confusion, so no warning should ever fire.
 			wantShadowed: false,
+			wantEnvVar:   EnvToken,
 		},
 		{
 			name:       "neither source",
@@ -79,7 +160,7 @@ func TestResolvePrecedence(t *testing.T) {
 		},
 		{
 			name:        "blank env falls through to config",
-			env:         "   ",
+			legacy:      "   ",
 			configToken: "file_token",
 			wantToken:   "file_token",
 			wantSource:  SourceConfig,
@@ -99,7 +180,10 @@ func TestResolvePrecedence(t *testing.T) {
 			} else {
 				isolateHome(t)
 			}
-			t.Setenv(EnvToken, tt.env)
+			// Set both unconditionally: neither may leak in from the
+			// developer's own environment.
+			t.Setenv(EnvToken, tt.legacy)
+			t.Setenv(EnvTokenAPI, tt.documented)
 
 			got := Resolve()
 			if got.Token != tt.wantToken {
@@ -111,6 +195,37 @@ func TestResolvePrecedence(t *testing.T) {
 			if got.Shadowed != tt.wantShadowed {
 				t.Errorf("Shadowed = %v, want %v", got.Shadowed, tt.wantShadowed)
 			}
+			if got.EnvVar != tt.wantEnvVar {
+				t.Errorf("EnvVar = %q, want %q", got.EnvVar, tt.wantEnvVar)
+			}
+			// EnvVar is named exactly when the env supplied the token; a
+			// message that names a variable the token did not come from is
+			// worse than naming none.
+			if got.FromEnv() != (got.EnvVar != "") {
+				t.Errorf("FromEnv()=%v disagrees with EnvVar=%q", got.FromEnv(), got.EnvVar)
+			}
+			var wantUnset []string
+			switch {
+			case tt.wantUnsetsBoth:
+				wantUnset = []string{EnvToken, EnvTokenAPI}
+			case tt.wantEnvVar != "":
+				wantUnset = []string{tt.wantEnvVar}
+			}
+			if !slices.Equal(got.EnvVarsSet, wantUnset) {
+				t.Errorf("EnvVarsSet = %v, want %v", got.EnvVarsSet, wantUnset)
+			}
+			// The winner must be the head of the list, or a caller reading
+			// EnvVarsSet[0] names a variable the token did not come from.
+			if len(got.EnvVarsSet) > 0 && got.EnvVarsSet[0] != got.EnvVar {
+				t.Errorf("EnvVarsSet[0] = %q but EnvVar = %q", got.EnvVarsSet[0], got.EnvVar)
+			}
+			// The hint has to name every variable: a user who clears only some
+			// of them still has one winning, and gets refused all over again.
+			for _, name := range got.EnvVarsSet {
+				if !strings.Contains(got.UnsetHint(), name) {
+					t.Errorf("UnsetHint() = %q, does not name %s", got.UnsetHint(), name)
+				}
+			}
 		})
 	}
 }
@@ -120,6 +235,7 @@ func TestResolvePrecedence(t *testing.T) {
 func TestAccessorsAgreeWithResolve(t *testing.T) {
 	writeConfigToken(t, `"   "`) // whitespace: previously HasToken=true, CheckAuth=false
 	t.Setenv(EnvToken, "")
+	t.Setenv(EnvTokenAPI, "")
 
 	res := Resolve()
 	if HasToken() != (res.Token != "") {
@@ -130,6 +246,9 @@ func TestAccessorsAgreeWithResolve(t *testing.T) {
 	}
 	if TokenFromEnv() != res.FromEnv() {
 		t.Errorf("TokenFromEnv()=%v but Resolve().FromEnv()=%v", TokenFromEnv(), res.FromEnv())
+	}
+	if res.EnvVar != "" {
+		t.Errorf("EnvVar=%q with no env token set, want empty", res.EnvVar)
 	}
 	if HasToken() {
 		t.Error("a whitespace-only config token must not count as a token")
@@ -197,5 +316,24 @@ func TestTokenWritesPreserveIndicesDir(t *testing.T) {
 	}
 	if c.Token != "" {
 		t.Errorf("after RemoveToken, Token = %q, want empty", c.Token)
+	}
+}
+
+// The hint is embedded in sentences, so it must read as a fragment and must
+// not name a shell: `unset` is not a command in any Windows shell, and the CLI
+// ships Windows binaries.
+func TestUnsetHintPhrasing(t *testing.T) {
+	tests := []struct {
+		names []string
+		want  string
+	}{
+		{nil, ""},
+		{[]string{EnvToken}, "clear VC_TOKEN from your environment"},
+		{[]string{EnvToken, EnvTokenAPI}, "clear VC_TOKEN and VULNCHECK_API_TOKEN from your environment"},
+	}
+	for _, tt := range tests {
+		if got := (Resolution{EnvVarsSet: tt.names}).UnsetHint(); got != tt.want {
+			t.Errorf("UnsetHint() with %v = %q, want %q", tt.names, got, tt.want)
+		}
 	}
 }

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -105,6 +105,26 @@ func TestResolvePrecedence(t *testing.T) {
 			wantEnvVar: EnvTokenAPI,
 		},
 		{
+			// A Kubernetes secret mounted from a file, or a sourced .env,
+			// arrives with the newline still attached. Untrimmed it reaches
+			// net/http, which refuses the Authorization header outright.
+			name:       "surrounding whitespace is trimmed off the env token",
+			documented: "  api_token\n",
+			wantToken:  "api_token",
+			wantSource: SourceEnv,
+			wantEnvVar: EnvTokenAPI,
+		},
+		{
+			// Same credential, different spelling. Reporting a conflict here
+			// would send the user unsetting a variable for no reason.
+			name:        "whitespace-only difference from config is not shadowing",
+			legacy:      "same_token\n",
+			configToken: "same_token",
+			wantToken:   "same_token",
+			wantSource:  SourceEnv,
+			wantEnvVar:  EnvToken,
+		},
+		{
 			name:        "config only",
 			configToken: "file_token",
 			wantToken:   "file_token",
@@ -316,6 +336,23 @@ func TestTokenWritesPreserveIndicesDir(t *testing.T) {
 	}
 	if c.Token != "" {
 		t.Errorf("after RemoveToken, Token = %q, want empty", c.Token)
+	}
+}
+
+// A padded paste saved verbatim fails every run afterwards, and unlike an
+// environment variable the user cannot see the padding to fix it.
+func TestSaveTokenTrimsWhitespace(t *testing.T) {
+	isolateHome(t)
+
+	if err := SaveToken("  vulncheck_padded_token\n"); err != nil {
+		t.Fatal(err)
+	}
+	c, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Token != "vulncheck_padded_token" {
+		t.Errorf("saved token = %q, want it trimmed", c.Token)
 	}
 }
 

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -168,7 +168,7 @@ var En = Copy{
 
 			Alternatively, use %[1]stoken%[1]s to specify an issued token directly.
 
-			Alternatively, vulncheck will use the authentication token found in the %[1]sVC_TOKEN%[1]s environment variable.
+			Alternatively, vulncheck will use the authentication token found in the %[1]sVULNCHECK_API_TOKEN%[1]s environment variable.
 			This method is most suitable for "headless" use of vulncheck such as in automation.
 		`, "`"),
 	AuthLoginExample: heredoc.Doc(`
@@ -178,7 +178,7 @@ var En = Copy{
 			# Authenticate with vulncheck.com by passing in a token
 			$ vulncheck auth login token vulncheck_******************
 	`),
-	AuthLoginErrorCI: "This command is interactive and cannot be run in a CI environment, use the VC_TOKEN environment variable instead",
+	AuthLoginErrorCI: "This command is interactive and cannot be run in a CI environment, use the VULNCHECK_API_TOKEN environment variable instead",
 
 	AuthLoginToken: "Connect a VulnCheck account using an authentication token",
 	AuthLoginWeb:   "Log in with a VulnCheck account using a web browser",
@@ -313,7 +313,7 @@ var En = Copy{
 	UpgradeStatusLong:  "Check if a new version of the CLI is available.",
 
 	ErrorUnauthorized: "Error: Unauthorized, Try authenticating with: vulncheck auth login",
-	ErrorNoToken:      "No token found. Please run `vulncheck auth login` to authenticate or populate the environment variable `VC_TOKEN`.",
+	ErrorNoToken:      "No token found. Please run `vulncheck auth login` to authenticate or populate the environment variable `VULNCHECK_API_TOKEN`.",
 
 	OfflineStatusShort: "Check the status of the offline database",
 	OfflineStatusLong:  "Check the status of the offline database",

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -12,11 +12,12 @@ import (
 	"github.com/vulncheck-oss/cli/pkg/ui"
 )
 
-// GuardEnvToken refuses a login when VC_TOKEN is set. Every login path writes
-// to the config file, but Resolve() prefers the environment — so the write
-// would be dead on arrival. Previously these paths verified the pasted token,
-// skipped the save, and still printed "Authenticated as ...", which is why a
-// user with a stale VC_TOKEN could log in repeatedly and never change anything.
+// GuardEnvToken refuses a login when a token environment variable is set.
+// Every login path writes to the config file, but Resolve() prefers the
+// environment — so the write would be dead on arrival. Previously these paths
+// verified the pasted token, skipped the save, and still printed
+// "Authenticated as ...", which is why a user with a stale VC_TOKEN could log
+// in repeatedly and never change anything.
 //
 // Callers must invoke this *before* prompting, so the user isn't asked to paste
 // a token or complete a browser flow that is going to be discarded.
@@ -27,16 +28,18 @@ func GuardEnvToken() error {
 	}
 
 	e := errs.Validation(
-		"%s is set and takes precedence over the config file, so logging in would have no effect",
-		config.EnvToken)
+		"%s is set, so the CLI already authenticates with it and `auth login` would have no effect",
+		res.EnvVar)
 	if res.Shadowed {
 		return e.WithHint(
-			"a different token is already saved in your config file. Run `unset %s` to use it, or keep using the environment token as-is.",
-			config.EnvToken)
+			"a different token is already saved in your config file. To use it, %s, or keep using the environment token as-is.",
+			res.UnsetHint())
 	}
+	// Exported on purpose by anyone running an SDK or the MCP server too, so
+	// lead with the fact that nothing is wrong.
 	return e.WithHint(
-		"run `unset %s` first if you want credentials stored in the config file.",
-		config.EnvToken)
+		"nothing to do if that is the token you want. To store a different credential in the config file instead, %s first.",
+		res.UnsetHint())
 }
 
 func ChooseAuthMethod() (string, error) {
@@ -118,9 +121,9 @@ func SaveToken(token string) error {
 	// changed which credential is in use. Login paths are already blocked by
 	// GuardEnvToken; this branch is reached by `auth status`, which re-verifies
 	// the active token without wanting to persist an environment value to disk.
-	if config.Resolve().FromEnv() {
+	if active := config.Resolve(); active.FromEnv() {
 		ui.Info(fmt.Sprintf("Verified as %s (%s) using the token from %s; config file not modified",
-			res.Data.Name, res.Data.Email, config.EnvToken))
+			res.Data.Name, res.Data.Email, active.EnvVar))
 		return nil
 	}
 

--- a/pkg/parity/README.md
+++ b/pkg/parity/README.md
@@ -11,7 +11,7 @@ small, seeded fixture set so regressions get caught at PR time.
 
 ```sh
 # Auth (same env var the CLI itself reads via config.Token()).
-export VC_TOKEN=...
+export VULNCHECK_API_TOKEN=...
 
 # Sync every index the fixtures reference.
 vulncheck offline sync --add cpecve

--- a/pkg/parity/parity_test.go
+++ b/pkg/parity/parity_test.go
@@ -13,7 +13,7 @@
 //
 // Run with:
 //
-//	VC_TOKEN=... go test -tags=parity ./pkg/parity/...
+//	VULNCHECK_API_TOKEN=... go test -tags=parity ./pkg/parity/...
 //
 // The build tag keeps this out of the default `go test ./...` run because it
 // needs a live token and locally synced indices; the test skips gracefully if
@@ -47,7 +47,7 @@ func noopProgress(int, int) {}
 func preflight(t *testing.T) cache.InfoFile {
 	t.Helper()
 	if config.Token() == "" {
-		t.Skip("parity test requires VC_TOKEN in env (or a logged-in CLI config)")
+		t.Skip("parity test requires VULNCHECK_API_TOKEN or VC_TOKEN in env (or a logged-in CLI config)")
 	}
 	indices, err := cache.Indices()
 	if err != nil {


### PR DESCRIPTION
## Accept VULNCHECK_API_TOKEN as a fallback token variable

The cli was the only VulnCheck client reading VC_TOKEN - the SDKs and MCP server use VULNCHECK_API_TOKEN. The cli now accepts either.

As per 3491, VC_TOKEN remains primary to avoid any breaking change, with VULNCHECK_API_TOKEN as a fallback - so now users can set one env var for all the open source products. VULNCHECK_API_TOKEN is now the documented name, but VC_TOKEN wins when both are set (to avoid changing behaviour for existing users), and an exported VULNCHECK_API_TOKEN is used above the config-file login, as  VC_TOKEN already did.

Some changes unrelated to the env var change:
* `ef2039a` - tokens are trimmed wherever they come from (env, config file, and on save). Strips trailing spaces etc
* `fdf8592` - the tests now stub the API instead of hitting production. Needed for the new tests, which assert on auth outcomes and so need a deterministic 401/200.

`go test ./...` green, vet and gofmt clean. Precedence matrix verified against a live token.