### PR TITLE
feature: add support for v4 advisory/backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ Every command below accepts the [global flags](#global-flags) (`--json`, `--quie
 - [`token`](#token) — API token management
 - [`indices`](#indices) — list or browse the catalogue of indices
 - [`index`](#index) — query one index
-- [`backup`](#backup) — download or fetch a signed URL for an index backup
+- [`advisory`](#advisory) — query v4 advisories in CVE Record Format 5.2
+- [`backup`](#backup) — download or fetch a signed URL for an index or advisory-feed backup
 - [`cpe`](#cpe) — look up CVEs for a CPE (single or batch)
 - [`purl`](#purl) — look up CVEs for a PURL (single or batch)
 - [`tag`](#tag) — look up IP-intelligence tag membership
@@ -256,14 +257,34 @@ vulncheck index browse <index> [query flags]
 `list --all` walks `next_cursor` end-to-end and emits one combined array. `browse` runs an interactive viewport; under `--json` (or `--no-interactive`) it falls back to `list` output. Query flags come from the index's schema (`--cve`, `--alias`, `--limit`, `--cursor`, etc.); see the [API docs](https://docs.vulncheck.com/api/indice) for the full set.
 
 
+### advisory
+
+```
+vulncheck advisory feeds [search]                      # GET /v4/advisory/list
+vulncheck advisory list [--full] [--all] [query flags] # GET /v4/advisory
+vulncheck advisory browse [--full] [query flags]
+```
+
+Every record is CVE Record Format 5.2, and there is one record per feed per CVE.
+
+At least one filter is required; see `advisory list --help` for the set (`--feed`, `--cve`, `--vendor`, `--purl`, `--updated-after`, …) and `advisory feeds` for `--feed` values. `--limit` caps at 100 and `--page × --limit` at 10,000 — page past that with `--start-cursor` and `--cursor`, or `--all` to walk it in one call (which buffers every record, so prefer cursors on the largest feeds). `browse` runs an interactive viewport.
+
+
 ### backup
 
 ```
-vulncheck backup url <index>       # signed temporary URL only
-vulncheck backup download <index>  # download the archive
+vulncheck backup list                       # indices with a backup available
+vulncheck backup url <index>                # signed temporary URL only
+vulncheck backup download <index>           # download the archive
+
+vulncheck backup advisory list              # GET /v4/backup
+vulncheck backup advisory url <feed>        # GET /v4/backup/{feed}
+vulncheck backup advisory download <feed>
 ```
 
 `download` picks the bubbletea progress bar for TTYs and a plain SIGINT-safe streaming download (writing to `<name>.part` and renaming on success) for headless callers. `url --json` returns `{filename, sha256, date_added, url}`.
+
+The `advisory` subcommands are a **different corpus, not a newer version** of the same archives, and most feed names are also index names — so the same argument usually addresses both. A v3 zip holds that feed's native records — for `sigmahq-sigma-rules` that includes the Sigma rule itself and its ATT&CK techniques — while the v4 zip holds CVE 5.2 records, one per CVE, dropping both those fields and every advisory with no CVE attached. A feed whose advisories are mostly not CVE-keyed can shrink to a fraction of its v3 record count. The v4 archive is a single `<feed>.jsonl` inside the zip, and its lists are parquet-shaped (`{"list":[{"element":…}]}`), so it is **not** a bulk copy of `advisory list --json`. The v4 object key carries no timestamp, so repeat downloads overwrite rather than accumulate — the command warns when it does. `url`/`download --json` carry `corpus` and `format` fields, because a bare `abbott.zip` on disk records nothing about which corpus produced it, and a `url` field so `jq -r .url` works against both.
 
 
 ### cpe

--- a/cmd/vulncheck/contract_test.go
+++ b/cmd/vulncheck/contract_test.go
@@ -161,7 +161,7 @@ func TestContractCommandsDumpIsUsableAndStable(t *testing.T) {
 			names[sm["name"].(string)] = true
 		}
 	}
-	for _, want := range []string{"scan", "cpe", "purl", "auth", "token", "indices", "index", "offline", "backup", "version"} {
+	for _, want := range []string{"scan", "cpe", "purl", "auth", "token", "indices", "index", "advisory", "offline", "backup", "version"} {
 		if !names[want] {
 			t.Errorf("commands dump missing top-level %q; got %v", want, names)
 		}

--- a/internal/errs/classify.go
+++ b/internal/errs/classify.go
@@ -82,6 +82,10 @@ func fromReqError(r sdk.ReqError) *Error {
 		e := Wrap(KindAuthInvalid, r, "%s", msg)
 		e.HTTPStatus = 401
 		return e
+	case 402:
+		e := Wrap(KindAuthInvalid, r, "%s", msg)
+		e.HTTPStatus = 402
+		return e
 	case 403:
 		e := Wrap(KindAuthInvalid, r, "%s", msg)
 		e.HTTPStatus = 403
@@ -112,6 +116,8 @@ func defaultMessageFor(r sdk.ReqError) string {
 	switch r.StatusCode {
 	case 401:
 		return "unauthorized: token is missing or invalid"
+	case 402:
+		return "payment required: this endpoint is not included in your subscription"
 	case 403:
 		return "forbidden: token lacks permission for this resource"
 	case 404:

--- a/internal/errs/errs_test.go
+++ b/internal/errs/errs_test.go
@@ -2,7 +2,9 @@ package errs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/vulncheck-oss/cli/pkg/sdk"
@@ -68,6 +70,7 @@ func TestClassifyMapsReqErrorByStatus(t *testing.T) {
 		want   Kind
 	}{
 		{401, KindAuthInvalid},
+		{402, KindAuthInvalid},
 		{403, KindAuthInvalid},
 		{404, KindNotFound},
 		{429, KindRateLimited},
@@ -112,5 +115,77 @@ func TestValidationHelperFormats(t *testing.T) {
 	}
 	if e.Error() != "need input" {
 		t.Errorf("message = %q, want %q", e.Error(), "need input")
+	}
+}
+
+// The v4 endpoints answer an unentitled token with 402 and a route-specific
+// message. That message is more precise than anything we could substitute, so
+// it must reach the user verbatim rather than being replaced by a generic hint.
+func TestClassifyPreservesEntitlementMessages(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+	}{
+		{"advisory", "This endpoint requires a valid trial or paid subscription"},
+		{"backup", "V4 backups require the Exploit & Vulnerability Intelligence subscription"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := sdk.ReqError{StatusCode: 402, Reason: sdk.MetaError{Error: true, Errors: []string{c.msg}}}
+			got := Classify(err)
+			if got == nil {
+				t.Fatal("Classify returned nil")
+			}
+			if got.Kind != KindAuthInvalid {
+				t.Errorf("kind = %s, want %s", got.Kind, KindAuthInvalid)
+			}
+			if got.HTTPStatus != 402 {
+				t.Errorf("HTTPStatus = %d, want 402", got.HTTPStatus)
+			}
+			if !strings.Contains(got.Error(), c.msg) {
+				t.Errorf("message %q does not carry the server's wording %q", got.Error(), c.msg)
+			}
+			// Exit 3 is the point of the 402 case: without it a 402 falls to
+			// the default 4xx branch and reports exit 2, telling a script to
+			// fix its query when the problem is its entitlement.
+			if code := got.Kind.ExitCode(); code != 3 {
+				t.Errorf("exit code = %d, want 3 (auth, not bad request)", code)
+			}
+		})
+	}
+}
+
+// Every status with a case in fromReqError needs a fallback message for a body
+// that does not decode, or the user sees "errors: []".
+func TestClassifyHasAFallbackMessageForEveryMappedStatus(t *testing.T) {
+	for _, status := range []int{401, 402, 403, 404, 429} {
+		got := Classify(sdk.ReqError{StatusCode: status})
+		if got == nil {
+			t.Fatalf("status=%d: Classify returned nil", status)
+		}
+		if got.Error() == "" || strings.Contains(got.Error(), "[]") {
+			t.Errorf("status=%d: message = %q, want a human fallback", status, got.Error())
+		}
+	}
+}
+
+// A v4 string-shaped error body must survive decoding all the way to the
+// surfaced message; before MetaError.UnmarshalJSON it arrived as an empty slice.
+func TestClassifySurfacesV4StringShapedErrors(t *testing.T) {
+	var metaError sdk.MetaError
+	body := `{"error":"feed not found: \"nosuchfeed\""}`
+	if err := json.Unmarshal([]byte(body), &metaError); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got := Classify(sdk.ReqError{StatusCode: 404, Reason: metaError})
+	if got == nil {
+		t.Fatal("Classify returned nil")
+	}
+	if got.Kind != KindNotFound {
+		t.Errorf("kind = %s, want %s", got.Kind, KindNotFound)
+	}
+	if !strings.Contains(got.Error(), "nosuchfeed") {
+		t.Errorf("message %q lost the feed name", got.Error())
 	}
 }

--- a/pkg/cmd/advisory/advisory.go
+++ b/pkg/cmd/advisory/advisory.go
@@ -198,6 +198,10 @@ func List() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list [flags]",
 		Short: i18n.C.AdvisoryListShort,
+		// v4 is a single index, so unlike `index list <index>` there is no
+		// positional to take. Accepting one silently would drop it and answer
+		// a broader question than the one asked.
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := output.FromCmd(cmd)
 
@@ -255,6 +259,7 @@ func Browse() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "browse [flags]",
 		Short: i18n.C.AdvisoryBrowseShort,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := output.FromCmd(cmd)
 

--- a/pkg/cmd/advisory/advisory.go
+++ b/pkg/cmd/advisory/advisory.go
@@ -1,0 +1,402 @@
+package advisory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"github.com/vulncheck-oss/cli/internal/errs"
+	"github.com/vulncheck-oss/cli/internal/output"
+	"github.com/vulncheck-oss/cli/pkg/config"
+	"github.com/vulncheck-oss/cli/pkg/i18n"
+	"github.com/vulncheck-oss/cli/pkg/sdk"
+	"github.com/vulncheck-oss/cli/pkg/session"
+	"github.com/vulncheck-oss/cli/pkg/ui"
+	"github.com/vulncheck-oss/cli/pkg/utils"
+)
+
+// queryOptions holds the flags shared by `list` and `browse`.
+//
+// The flags are declared explicitly rather than reflected off the parameter
+// struct, as pkg/cmd/index does. Three reasons: /v4/advisory needs int and bool
+// parameters as well as strings, --feed has to be renamed off its "name" wire
+// parameter, and the API answers an unrecognised parameter with an empty result
+// set instead of an error -- so the set that reaches the wire wants to be
+// written out and reviewed, not derived.
+type queryOptions struct {
+	feed            string
+	cve             string
+	vendor          string
+	product         string
+	platform        string
+	version         string
+	cpe             string
+	purl            string
+	packageName     string
+	referenceURL    string
+	referenceTag    string
+	descriptionLang string
+	updatedAfter    string
+	updatedBefore   string
+	limit           int
+	page            int
+	cursor          string
+	startCursor     bool
+	all             bool
+	full            bool
+}
+
+func (o *queryOptions) register(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.feed, "feed", "", "Filter by advisory feed name (see 'vulncheck advisory feeds')")
+	cmd.Flags().StringVar(&o.cve, "cve", "", "Filter by CVE ID, e.g. CVE-2019-12255")
+	cmd.Flags().StringVar(&o.vendor, "vendor", "", "Filter by vendor name")
+	cmd.Flags().StringVar(&o.product, "product", "", "Filter by product name")
+	cmd.Flags().StringVar(&o.platform, "platform", "", "Filter by OS or platform")
+	cmd.Flags().StringVar(&o.version, "version", "", "Filter by product version (semver aware)")
+	cmd.Flags().StringVar(&o.cpe, "cpe", "", "Filter by CPE")
+	cmd.Flags().StringVar(&o.purl, "purl", "", "Filter by package URL")
+	cmd.Flags().StringVar(&o.packageName, "package-name", "", "Filter by package name")
+	cmd.Flags().StringVar(&o.referenceURL, "reference-url", "", "Filter by reference URL")
+	cmd.Flags().StringVar(&o.referenceTag, "reference-tag", "", "Filter by reference tag")
+	cmd.Flags().StringVar(&o.descriptionLang, "description-lang", "", "Filter by description language")
+	cmd.Flags().StringVar(&o.updatedAfter, "updated-after", "", "Updated after an RFC3339 date or date-math, e.g. now-30d")
+	cmd.Flags().StringVar(&o.updatedBefore, "updated-before", "", "Updated before an RFC3339 date or date-math")
+	cmd.Flags().IntVar(&o.limit, "limit", 0,
+		fmt.Sprintf("Records per page (max %d, default %d); ignored by --all", sdk.MaxAdvisoryLimit, sdk.DefaultAdvisoryLimit))
+	cmd.Flags().IntVar(&o.page, "page", 0, "Page number; page x limit may not exceed 10000")
+	cmd.Flags().StringVar(&o.cursor, "cursor", "",
+		"Continue from a next_cursor value emitted by --full; the only way past the result window without --all")
+	cmd.Flags().BoolVar(&o.startCursor, "start-cursor", false,
+		"Begin cursor pagination, so --full reports a next_cursor to continue from")
+	cmd.Flags().BoolVar(&o.all, "all", false,
+		fmt.Sprintf("Auto-paginate via cursor at the maximum page size (%d) and emit every matching record; cannot be combined with --page", sdk.MaxAdvisoryLimit))
+	cmd.Flags().BoolVarP(&o.full, "full", "f", false, "Output the full response envelope, including _meta")
+}
+
+func (o *queryOptions) params() sdk.AdvisoryQueryParameters {
+	return sdk.AdvisoryQueryParameters{
+		Name:            o.feed,
+		CveID:           o.cve,
+		Vendor:          o.vendor,
+		Product:         o.product,
+		Platform:        o.platform,
+		Version:         o.version,
+		CPE:             o.cpe,
+		PURL:            o.purl,
+		PackageName:     o.packageName,
+		ReferenceURL:    o.referenceURL,
+		ReferenceTag:    o.referenceTag,
+		DescriptionLang: o.descriptionLang,
+		UpdatedAfter:    o.updatedAfter,
+		UpdatedBefore:   o.updatedBefore,
+		Limit:           o.limit,
+		Page:            o.page,
+		Cursor:          o.cursor,
+		StartCursor:     o.startCursor,
+	}
+}
+
+// validate turns the SDK's pre-flight checks into classified CLI errors so they
+// exit 2 as validation problems rather than 1 as internal ones.
+func (o *queryOptions) validate() error {
+	params := o.params()
+	if o.all && o.page > 0 {
+		return errs.Validation("--all cannot be combined with --page; --all pages through everything via cursor")
+	}
+	if o.all && (o.cursor != "" || o.startCursor) {
+		return errs.Validation("--all cannot be combined with --cursor or --start-cursor; it drives cursor pagination itself")
+	}
+	if o.all && o.limit > 0 && o.limit != sdk.MaxAdvisoryLimit {
+		return errs.Validation(
+			"--all cannot be combined with --limit %d; it always walks at the maximum page size of %d",
+			o.limit, sdk.MaxAdvisoryLimit)
+	}
+	if o.all {
+		// --all drives cursor pagination, so the offset ceiling does not apply.
+		params.Page = 0
+	}
+	if err := params.Validate(); err != nil {
+		return errs.Validation("%s", err)
+	}
+	return nil
+}
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "advisory <command>",
+		Short: i18n.C.AdvisoryShort,
+	}
+
+	cmd.AddCommand(Feeds())
+	cmd.AddCommand(List())
+	cmd.AddCommand(Browse())
+
+	return cmd
+}
+
+// Feeds lists the advisory feed catalogue.
+//
+// This is GET /v4/advisory/list. It is spelled `feeds` rather than `list`
+// because the API and the CLI use "list" in opposite senses: in the URL /list
+// is the catalogue, while in the CLI `list` means records, as it does for
+// `vulncheck index list`. Keeping the CLI self-consistent was judged the more
+// useful of the two consistencies.
+func Feeds() *cobra.Command {
+	return &cobra.Command{
+		Use:   "feeds [search]",
+		Short: i18n.C.AdvisoryFeedsShort,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.FromCmd(cmd)
+
+			search := ""
+			if len(args) > 0 {
+				search = args[0]
+			}
+
+			client := session.ConnectWithContext(cmd.Context(), config.Token())
+			response, err := client.GetAdvisoryFeeds()
+			if err != nil {
+				return err
+			}
+			if response == nil {
+				return errs.New(errs.KindInternal, "empty response from /v4/advisory/list")
+			}
+
+			// Best-effort: v4 backup is a separate entitlement from v4
+			// advisory, so a caller entitled to the feed list may still be
+			// refused the backup list. Degrade to the name column rather than
+			// failing a command they are entitled to run.
+			var backups []sdk.AdvisoryBackupMeta
+			withBackups := false
+			if backupResponse, backupErr := client.GetAdvisoryBackups(); backupErr == nil && backupResponse != nil {
+				backups = backupResponse.GetData()
+				withBackups = true
+			}
+
+			rows := ui.AdvisoryFeeds(response.GetData(), backups, search)
+
+			if r.IsJSON() {
+				return r.JSON(rows)
+			}
+
+			if search != "" {
+				r.Info(i18n.C.AdvisoryFeedsSearch, len(rows), search)
+			} else {
+				r.Info(i18n.C.AdvisoryFeedsFull, len(rows))
+			}
+			return ui.AdvisoryFeedsList(rows, withBackups)
+		},
+	}
+}
+
+func List() *cobra.Command {
+	opts := &queryOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list [flags]",
+		Short: i18n.C.AdvisoryListShort,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.FromCmd(cmd)
+
+			if err := opts.validate(); err != nil {
+				return err
+			}
+
+			client := session.ConnectWithContext(cmd.Context(), config.Token())
+			response, pages, err := fetch(cmd.Context(), client, opts, r.Interactive())
+			if err != nil {
+				return err
+			}
+
+			if r.IsJSON() {
+				if opts.full {
+					return r.JSON(response)
+				}
+				return r.JSON(response.GetData())
+			}
+
+			views := sdk.ParseAdvisoryRecords(response.GetData())
+			r.Info(i18n.C.AdvisoryFound, len(views), response.Meta.Total)
+			if opts.full {
+				// Without this --full would be a silent no-op outside --json.
+				//
+				// A cursor-mode response always echoes page 1, so after a
+				// completed walk "Page 1 of 32" would say the opposite of what
+				// happened; the terminal cursor is equally meaningless there.
+				// Under --all these are facts about the request rather than
+				// the response: the synthesised envelope reports one page of
+				// everything, so echoing its limit here would just restate
+				// the record count.
+				if opts.all {
+					r.Stat("Pages walked", fmt.Sprintf("%d", pages))
+					r.Stat("Page size", fmt.Sprintf("%d", sdk.MaxAdvisoryLimit))
+				} else {
+					r.Stat("Page", fmt.Sprintf("%d of %d", response.Meta.Page, response.Meta.Pages))
+					r.Stat("Limit", fmt.Sprintf("%d", response.Meta.Limit))
+					if response.Meta.NextCursor != "" {
+						r.Stat("Next cursor", response.Meta.NextCursor)
+					}
+				}
+			}
+			return ui.AdvisoryList(views)
+		},
+	}
+
+	opts.register(cmd)
+	return cmd
+}
+
+func Browse() *cobra.Command {
+	opts := &queryOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "browse [flags]",
+		Short: i18n.C.AdvisoryBrowseShort,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.FromCmd(cmd)
+
+			if err := opts.validate(); err != nil {
+				return err
+			}
+
+			client := session.ConnectWithContext(cmd.Context(), config.Token())
+			response, _, err := fetch(cmd.Context(), client, opts, r.Interactive())
+			if err != nil {
+				return err
+			}
+
+			var viewportOutput interface{} = response.GetData()
+			if opts.full {
+				viewportOutput = response
+			}
+
+			// browse is interactive; fall back to JSON whenever the TUI cannot
+			// render, matching `vulncheck index browse`.
+			if r.IsJSON() || !r.Interactive() {
+				return r.JSON(viewportOutput)
+			}
+
+			ui.Viewport("advisory", viewportOutput)
+			return nil
+		},
+	}
+
+	opts.register(cmd)
+	return cmd
+}
+
+// fetch runs the query and returns the whole response, so callers can emit
+// either the records alone or the full envelope.
+//
+// An unknown feed name is not an error at the API -- /v4/advisory answers HTTP
+// 200 with an empty page -- so a zero-result query with --feed set is checked
+// against the catalogue, and retried if the user picks a correction.
+func fetch(ctx context.Context, client *sdk.Client, opts *queryOptions, interactive bool) (*sdk.AdvisoryResponse, int, error) {
+	params := opts.params()
+	if opts.all {
+		params.Page = 0
+	}
+
+	response, pages, err := runQuery(client, opts.all, params)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if len(response.GetData()) == 0 && opts.feed != "" {
+		corrected, feedErr := checkFeed(ctx, client, opts.feed, interactive)
+		if feedErr != nil {
+			return nil, 0, feedErr
+		}
+		if corrected != "" && corrected != opts.feed {
+			params.Name = corrected
+			return runQuery(client, opts.all, params)
+		}
+	}
+
+	return response, pages, nil
+}
+
+// runQuery issues one query, collapsing the paged and cursor-walked forms into
+// the same response shape.
+func runQuery(client *sdk.Client, all bool, params sdk.AdvisoryQueryParameters) (*sdk.AdvisoryResponse, int, error) {
+	if all {
+		records, pages, err := client.GetAllAdvisories(params)
+		if err != nil {
+			return nil, 0, err
+		}
+		// The last page's metadata would report page 1 of N with a filtered
+		// count of that page alone, contradicting the data beside it. The
+		// API's own total is an estimate -- it under-reports a completed walk
+		// -- so the walked count is both self-consistent and more accurate.
+		n := len(records)
+		return &sdk.AdvisoryResponse{
+			Data: records,
+			Meta: sdk.AdvisoryMeta{Total: n, Page: 1, Pages: 1, Limit: n, Filtered: n},
+		}, pages, nil
+	}
+
+	response, err := client.GetAdvisories(params)
+	if err != nil {
+		return nil, 0, err
+	}
+	if response == nil {
+		return nil, 0, errs.New(errs.KindInternal, "empty response from /v4/advisory")
+	}
+	return response, 0, nil
+}
+
+// checkFeed validates a feed name once a query has already come back empty, so
+// the common path costs no extra request.
+//
+// It returns a corrected name when the user picks one from the suggestions, so
+// the caller can retry -- the same prompt-then-retry flow `backup` uses for
+// index names, rather than telling the user to run the command again.
+func checkFeed(ctx context.Context, client *sdk.Client, feed string, interactive bool) (string, error) {
+	response, err := client.GetAdvisoryFeeds()
+	if err != nil || response == nil {
+		// The catalogue is only being used to improve an error message; if it
+		// is unavailable, let the empty result stand.
+		return "", nil
+	}
+
+	names := make([]string, 0, len(response.GetData()))
+	for _, f := range response.GetData() {
+		if f.Name == feed {
+			return "", nil
+		}
+		names = append(names, f.Name)
+	}
+
+	suggestions := utils.SuggestFor(feed, names)
+	if len(suggestions) == 0 {
+		return "", errs.Validation("advisory feed '%s' does not exist", feed)
+	}
+
+	if !interactive {
+		return "", errs.Validation("advisory feed '%s' does not exist; did you mean: %s",
+			feed, strings.Join(suggestions, ", "))
+	}
+
+	options := make([]huh.Option[string], len(suggestions))
+	for i, s := range suggestions {
+		options[i] = huh.NewOption(s, s)
+	}
+
+	var selected string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("advisory feed '%s' does not exist. Did you mean one of these?", feed)).
+				Options(options...).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil || selected == "" {
+		return "", errs.Validation("advisory feed '%s' does not exist", feed)
+	}
+
+	return selected, nil
+}

--- a/pkg/cmd/advisory/advisory_test.go
+++ b/pkg/cmd/advisory/advisory_test.go
@@ -1,0 +1,161 @@
+package advisory
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/vulncheck-oss/cli/pkg/i18n"
+	"github.com/vulncheck-oss/cli/pkg/sdk"
+)
+
+func init() { i18n.Init() }
+
+func TestCommandStructure(t *testing.T) {
+	cmd := Command()
+
+	if cmd.Use != "advisory <command>" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "advisory <command>")
+	}
+	if cmd.Short == "" {
+		t.Error("Short must be set from i18n")
+	}
+
+	var names []string
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	sort.Strings(names)
+
+	want := []string{"browse", "feeds", "list"}
+	if len(names) != len(want) {
+		t.Fatalf("subcommands = %v, want %v", names, want)
+	}
+	for i, n := range want {
+		if names[i] != n {
+			t.Errorf("subcommands = %v, want %v", names, want)
+			break
+		}
+	}
+}
+
+// The flag set is the CLI half of a closed contract: /v4/advisory answers an
+// unrecognised parameter with an empty result set rather than an error, so a
+// flag that no longer maps to a parameter is silent data loss. Pin it.
+func TestQueryFlagsAreTheDocumentedSet(t *testing.T) {
+	want := []string{
+		"all", "cpe", "cursor", "cve", "description-lang", "feed", "full",
+		"limit", "package-name", "page", "platform", "product", "purl",
+		"reference-tag", "reference-url", "start-cursor", "updated-after",
+		"updated-before", "vendor", "version",
+	}
+
+	for _, cmd := range []*cobra.Command{List(), Browse()} {
+		var got []string
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { got = append(got, f.Name) })
+		sort.Strings(got)
+
+		if len(got) != len(want) {
+			t.Fatalf("%s flags = %v, want %v", cmd.Name(), got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("%s flags = %v, want %v", cmd.Name(), got, want)
+				break
+			}
+		}
+	}
+}
+
+// --feed is deliberately renamed off its "name" wire parameter, because "name"
+// collides with too much else in a CVE record to read well as a flag.
+// The cursor flags exist so that --full's next_cursor can be handed back; the
+// SDK plumbing they drive already runs on every --all.
+func TestCursorFlagsReachTheQueryParameters(t *testing.T) {
+	params := (&queryOptions{feed: "ghsa", cursor: "abc", startCursor: true}).params()
+	if params.Cursor != "abc" {
+		t.Errorf("Cursor = %q, want abc", params.Cursor)
+	}
+	if !params.StartCursor {
+		t.Error("StartCursor should be set")
+	}
+}
+
+func TestFeedFlagMapsToTheNameParameter(t *testing.T) {
+	opts := &queryOptions{feed: "ghsa", cve: "CVE-2019-12255", packageName: "pkg"}
+	params := opts.params()
+
+	if params.Name != "ghsa" {
+		t.Errorf("Name = %q, want %q", params.Name, "ghsa")
+	}
+	if params.CveID != "CVE-2019-12255" {
+		t.Errorf("CveID = %q, want %q", params.CveID, "CVE-2019-12255")
+	}
+	if params.PackageName != "pkg" {
+		t.Errorf("PackageName = %q, want %q", params.PackageName, "pkg")
+	}
+}
+
+// --all overrides both page and limit, so accepting either silently would
+// discard something the user asked for.
+func TestValidateRejectsAllWithPagingFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		opts *queryOptions
+		want string
+	}{
+		{"page", &queryOptions{feed: "ghsa", all: true, page: 3}, "--page"},
+		{"limit below the maximum", &queryOptions{feed: "ghsa", all: true, limit: 5}, "--limit"},
+		{"cursor", &queryOptions{feed: "ghsa", all: true, cursor: "abc"}, "--cursor"},
+		{"start-cursor", &queryOptions{feed: "ghsa", all: true, startCursor: true}, "--cursor"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.validate()
+			if err == nil {
+				t.Fatalf("expected --all with %s to be rejected", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("message %q should name %s", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+// --limit 100 asks for exactly what --all already does, so rejecting it would
+// be refusing a request that is being honoured.
+func TestValidateAcceptsAllWithTheMaximumLimit(t *testing.T) {
+	if err := (&queryOptions{feed: "ghsa", all: true, limit: sdk.MaxAdvisoryLimit}).validate(); err != nil {
+		t.Errorf("--all --limit %d should be accepted: %v", sdk.MaxAdvisoryLimit, err)
+	}
+}
+
+// --all pages by cursor, so the offset ceiling that would reject this query
+// without --all must not apply to it.
+func TestValidateIgnoresTheOffsetCeilingUnderAll(t *testing.T) {
+	if err := (&queryOptions{feed: "ghsa", all: true}).validate(); err != nil {
+		t.Errorf("--all should be accepted: %v", err)
+	}
+	if err := (&queryOptions{feed: "ghsa", page: 1001}).validate(); err == nil {
+		t.Error("page 1001 at the default limit exceeds the result window and should be rejected")
+	}
+}
+
+func TestValidateRequiresAFilter(t *testing.T) {
+	if err := (&queryOptions{limit: 10}).validate(); err == nil {
+		t.Error("an unfiltered query would walk the whole corpus and must be rejected")
+	}
+	if err := (&queryOptions{cve: "CVE-2019-12255"}).validate(); err != nil {
+		t.Errorf("a filtered query should be accepted: %v", err)
+	}
+}
+
+func TestHelpDoesNotError(t *testing.T) {
+	for _, cmd := range []*cobra.Command{Command(), Feeds(), List(), Browse()} {
+		cmd.SetArgs([]string{"--help"})
+		if err := cmd.Help(); err != nil {
+			t.Errorf("%s --help: %v", cmd.Name(), err)
+		}
+	}
+}

--- a/pkg/cmd/advisory/advisory_test.go
+++ b/pkg/cmd/advisory/advisory_test.go
@@ -41,6 +41,38 @@ func TestCommandStructure(t *testing.T) {
 	}
 }
 
+// `index list <index> --cve X` is the shape a v3 user translates from, and
+// cobra's default accepts a positional and then ignores it -- so the feed name
+// was dropped and the query answered across every feed, at exit 0.
+func TestPositionalArgumentsAreValidated(t *testing.T) {
+	cases := []struct {
+		cmd        *cobra.Command
+		wantReject []string
+		wantAccept [][]string
+	}{
+		{List(), []string{"ghsa"}, [][]string{nil}},
+		{Browse(), []string{"ghsa"}, [][]string{nil}},
+		// feeds takes an optional search term, so one is fine and two are not.
+		{Feeds(), []string{"a", "b"}, [][]string{nil, {"ghsa"}}},
+	}
+
+	for _, tt := range cases {
+		name := tt.cmd.Name()
+		if tt.cmd.Args == nil {
+			t.Errorf("%s: no Args validator; cobra would accept and silently drop positionals", name)
+			continue
+		}
+		if err := tt.cmd.ValidateArgs(tt.wantReject); err == nil {
+			t.Errorf("%s: accepted %v", name, tt.wantReject)
+		}
+		for _, args := range tt.wantAccept {
+			if err := tt.cmd.ValidateArgs(args); err != nil {
+				t.Errorf("%s: rejected %v: %v", name, args, err)
+			}
+		}
+	}
+}
+
 // The flag set is the CLI half of a closed contract: /v4/advisory answers an
 // unrecognised parameter with an empty result set rather than an error, so a
 // flag that no longer maps to a parameter is silent data loss. Pin it.

--- a/pkg/cmd/backup/advisory.go
+++ b/pkg/cmd/backup/advisory.go
@@ -1,0 +1,254 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"github.com/vulncheck-oss/cli/internal/errs"
+	"github.com/vulncheck-oss/cli/internal/output"
+	"github.com/vulncheck-oss/cli/pkg/config"
+	"github.com/vulncheck-oss/cli/pkg/i18n"
+	"github.com/vulncheck-oss/cli/pkg/sdk"
+	"github.com/vulncheck-oss/cli/pkg/session"
+	"github.com/vulncheck-oss/cli/pkg/ui"
+	"github.com/vulncheck-oss/cli/pkg/utils"
+)
+
+// validateFeed mirrors validateIndex for the v4 feed namespace. Unlike the
+// advisory query endpoint, /v4/backup/{feed} does return 404 for an unknown
+// feed, so this is only reached once a request has already failed.
+func validateFeed(ctx context.Context, feed string, interactive bool) (string, error) {
+	response, err := session.ConnectWithContext(ctx, config.Token()).GetAdvisoryBackups()
+	if err != nil {
+		return "", err
+	}
+	if response == nil {
+		return "", errs.Validation("advisory feed '%s' does not exist", feed)
+	}
+
+	var names []string
+	available := make(map[string]bool)
+	for _, f := range response.GetData() {
+		available[f.Name] = true
+		names = append(names, f.Name)
+	}
+
+	if available[feed] {
+		return feed, nil
+	}
+
+	suggestions := utils.SuggestFor(feed, names)
+	if len(suggestions) == 0 {
+		return "", errs.Validation("advisory feed '%s' does not exist", feed)
+	}
+
+	if !interactive {
+		joined := suggestions[0]
+		for _, s := range suggestions[1:] {
+			joined += ", " + s
+		}
+		return "", errs.Validation("advisory feed '%s' does not exist; did you mean: %s", feed, joined)
+	}
+
+	options := make([]huh.Option[string], len(suggestions))
+	for i, s := range suggestions {
+		options[i] = huh.NewOption(s, s)
+	}
+
+	var selected string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("advisory feed '%s' does not exist. Did you mean one of these?", feed)).
+				Options(options...).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil || selected == "" {
+		return "", errs.Validation("advisory feed '%s' does not exist", feed)
+	}
+
+	return selected, nil
+}
+
+// fetchAdvisoryBackup resolves a feed to its backup, retrying once against a
+// corrected feed name when the first attempt 404s.
+func fetchAdvisoryBackup(cmd *cobra.Command, feed string, interactive bool) (*sdk.AdvisoryBackup, string, error) {
+	client := session.ConnectWithContext(cmd.Context(), config.Token())
+
+	backup, err := client.GetAdvisoryBackup(feed)
+	if err != nil {
+		// Only a 404 means "no such feed". Re-resolving an entitlement or
+		// server error through the catalogue costs an extra request and cannot
+		// change the outcome.
+		reqErr, ok := err.(sdk.ReqError)
+		if !ok || reqErr.StatusCode != http.StatusNotFound {
+			return nil, feed, err
+		}
+		corrected, validationErr := validateFeed(cmd.Context(), feed, interactive)
+		if validationErr != nil {
+			return nil, feed, validationErr
+		}
+		feed = corrected
+		if backup, err = client.GetAdvisoryBackup(feed); err != nil {
+			return nil, feed, err
+		}
+	}
+
+	if backup == nil {
+		return nil, feed, errs.New(errs.KindInternal, "empty response from /v4/backup/%s", feed)
+	}
+	if !backup.Available || backup.URL == "" {
+		return nil, feed, errs.NotFound(i18n.C.BackupAdvisoryUnavailable, feed)
+	}
+
+	return backup, feed, nil
+}
+
+// advisoryBackupOutput adds provenance the API does not send. A downloaded
+// abbott.zip is indistinguishable on disk from its v3 namesake, so --json names
+// the corpus and the archive format explicitly.
+type advisoryBackupOutput struct {
+	*sdk.AdvisoryBackup
+	Corpus string `json:"corpus"`
+	Format string `json:"format"`
+}
+
+const (
+	advisoryCorpus = "v4-advisory"
+	advisoryFormat = "zip/jsonl"
+)
+
+// advisoryCommand groups the v4 advisory feed backups.
+//
+// These sit under `backup` rather than beside the advisory query commands so
+// that everything bulk-download-shaped is discoverable in one place, and they
+// are named for the corpus rather than the API version because that is the real
+// distinction: a v4 zip holds CVE 5.2 records, one per CVE, while the v3 zip for
+// the same name holds that feed's native records including any without a CVE.
+func advisoryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "advisory <command>",
+		Short: i18n.C.BackupAdvisoryShort,
+	}
+
+	cmdList := &cobra.Command{
+		Use:   "list",
+		Short: i18n.C.BackupAdvisoryListShort,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.FromCmd(cmd)
+
+			response, err := session.ConnectWithContext(cmd.Context(), config.Token()).GetAdvisoryBackups()
+			if err != nil {
+				return err
+			}
+			if response == nil {
+				return errs.New(errs.KindInternal, "empty response from /v4/backup")
+			}
+
+			if r.IsJSON() {
+				return r.JSON(response.GetData())
+			}
+
+			r.Info(i18n.C.BackupAdvisoryListFull, len(response.GetData()))
+			return ui.AdvisoryBackupsList(response.GetData())
+		},
+	}
+
+	cmdUrl := &cobra.Command{
+		Use:   "url <feed>",
+		Short: i18n.C.BackupAdvisoryUrlShort,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.FromCmd(cmd)
+			if len(args) != 1 {
+				return ui.Error(i18n.C.BackupAdvisoryErrorRequired)
+			}
+
+			backup, _, err := fetchAdvisoryBackup(cmd, args[0], r.Interactive())
+			if err != nil {
+				return err
+			}
+
+			if r.IsJSON() {
+				return r.JSON(advisoryBackupOutput{
+					AdvisoryBackup: backup,
+					Corpus:         advisoryCorpus,
+					Format:         advisoryFormat,
+				})
+			}
+
+			// v4 carries no filename or date_added -- backup_written_at lives
+			// on the list endpoint -- so the checksum and expiry are what there
+			// is to report. Corpus is named because the same feed name also
+			// addresses a v3 index backup holding different data.
+			r.Stat("Feed", backup.Feed)
+			r.Stat("Corpus", advisoryCorpus)
+			r.Stat("Format", advisoryFormat)
+			r.Stat("SHA256", backup.SHA256)
+			r.Stat("Expires", backup.URLExpires)
+			r.Stat("URL", backup.URL)
+			return nil
+		},
+	}
+
+	cmdDownload := &cobra.Command{
+		Use:   "download <feed>",
+		Short: i18n.C.BackupAdvisoryDownloadShort,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.FromCmd(cmd)
+			if len(args) != 1 {
+				return ui.Error(i18n.C.BackupAdvisoryErrorRequired)
+			}
+
+			backup, feed, err := fetchAdvisoryBackup(cmd, args[0], r.Interactive())
+			if err != nil {
+				return err
+			}
+
+			// The v4 object key carries no timestamp, so this resolves to
+			// "<feed>.zip" and a repeat download overwrites the previous one.
+			// That is distinct from the v3 name, which embeds a timestamp.
+			file, err := utils.BackupFilename(backup.URL)
+			if err != nil {
+				return err
+			}
+
+			r.Info(i18n.C.BackupAdvisoryDownloadInfo, feed)
+			r.Info(i18n.C.BackupDownloadProgress, file)
+			r.Warn(i18n.C.BackupAdvisoryOverwrite, file)
+
+			downloadErr := func() error {
+				if r.Interactive() {
+					return ui.Download(backup.URL, file)
+				}
+				return ui.DownloadHeadless(cmd.Context(), backup.URL, file, r.Stderr())
+			}()
+			if downloadErr != nil {
+				return downloadErr
+			}
+
+			if r.IsJSON() {
+				return r.JSON(map[string]any{
+					"feed":     feed,
+					"corpus":   advisoryCorpus,
+					"format":   advisoryFormat,
+					"file":     file,
+					"sha256":   backup.SHA256,
+					"complete": true,
+				})
+			}
+			r.Success("%s", i18n.C.BackupDownloadComplete)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(cmdList)
+	cmd.AddCommand(cmdUrl)
+	cmd.AddCommand(cmdDownload)
+
+	return cmd
+}

--- a/pkg/cmd/backup/advisory_test.go
+++ b/pkg/cmd/backup/advisory_test.go
@@ -1,0 +1,94 @@
+package backup
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/vulncheck-oss/cli/pkg/i18n"
+)
+
+func init() { i18n.Init() }
+
+// v4 backups sit under `backup` so that everything bulk-download-shaped is
+// discoverable in one place, and are named for the corpus rather than the API
+// version: the v4 zip for a given name holds different data from the v3 one.
+func TestBackupCommandStructure(t *testing.T) {
+	var names []string
+	for _, sub := range Command().Commands() {
+		names = append(names, sub.Name())
+	}
+	sort.Strings(names)
+
+	want := []string{"advisory", "download", "list", "url"}
+	if len(names) != len(want) {
+		t.Fatalf("subcommands = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("subcommands = %v, want %v", names, want)
+			break
+		}
+	}
+}
+
+func TestBackupAdvisoryCommandStructure(t *testing.T) {
+	cmd := advisoryCommand()
+
+	if cmd.Use != "advisory <command>" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "advisory <command>")
+	}
+
+	var names []string
+	for _, sub := range cmd.Commands() {
+		names = append(names, sub.Name())
+	}
+	sort.Strings(names)
+
+	want := []string{"download", "list", "url"}
+	if len(names) != len(want) {
+		t.Fatalf("subcommands = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("subcommands = %v, want %v", names, want)
+			break
+		}
+	}
+}
+
+// The v3 subcommands take an <index>; the v4 ones take a <feed>. The wording is
+// the only thing telling a user which corpus they are addressing, since most v4
+// feed names are also v3 index names.
+func TestBackupSubcommandsNameTheirArgument(t *testing.T) {
+	uses := map[string]string{}
+	for _, sub := range Command().Commands() {
+		uses[sub.Name()] = sub.Use
+	}
+	for _, sub := range advisoryCommand().Commands() {
+		uses["advisory "+sub.Name()] = sub.Use
+	}
+
+	cases := map[string]string{
+		"url":               "url <index>",
+		"download":          "download <index>",
+		"advisory url":      "url <feed>",
+		"advisory download": "download <feed>",
+	}
+	for name, want := range cases {
+		if uses[name] != want {
+			t.Errorf("%s: Use = %q, want %q", name, uses[name], want)
+		}
+	}
+}
+
+func TestBackupHelpDoesNotError(t *testing.T) {
+	cmd := Command()
+	if err := cmd.Help(); err != nil {
+		t.Errorf("backup --help: %v", err)
+	}
+	for _, sub := range cmd.Commands() {
+		if err := sub.Help(); err != nil {
+			t.Errorf("backup %s --help: %v", sub.Name(), err)
+		}
+	}
+}

--- a/pkg/cmd/backup/backup.go
+++ b/pkg/cmd/backup/backup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
+	"github.com/vulncheck-oss/cli/internal/errs"
 	"github.com/vulncheck-oss/cli/internal/output"
 	"github.com/vulncheck-oss/cli/pkg/config"
 	"github.com/vulncheck-oss/cli/pkg/i18n"
@@ -73,6 +74,31 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "backup <command>",
 		Short: i18n.C.BackupShort,
+		Long:  i18n.C.BackupLong,
+	}
+
+	cmdList := &cobra.Command{
+		Use:   "list",
+		Short: i18n.C.BackupListShort,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.FromCmd(cmd)
+
+			response, err := session.ConnectWithContext(cmd.Context(), config.Token()).GetBackups()
+			if err != nil {
+				return err
+			}
+			if response == nil {
+				return errs.New(errs.KindInternal, "empty response from /v3/backup")
+			}
+
+			if r.IsJSON() {
+				return r.JSON(response.GetData())
+			}
+
+			r.Info(i18n.C.BackupListFull, len(response.GetData()))
+			return ui.BackupsList(response.GetData())
+		},
 	}
 
 	cmdUrl := &cobra.Command{
@@ -180,8 +206,10 @@ func Command() *cobra.Command {
 		},
 	}
 
+	cmd.AddCommand(cmdList)
 	cmd.AddCommand(cmdUrl)
 	cmd.AddCommand(cmdDownload)
+	cmd.AddCommand(advisoryCommand())
 
 	return cmd
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/spf13/cobra"
 	"github.com/vulncheck-oss/cli/pkg/cmd/about"
+	"github.com/vulncheck-oss/cli/pkg/cmd/advisory"
 	"github.com/vulncheck-oss/cli/pkg/cmd/auth"
 	"github.com/vulncheck-oss/cli/pkg/cmd/backup"
 	"github.com/vulncheck-oss/cli/pkg/cmd/commands"
@@ -102,6 +103,7 @@ func NewCmdRoot() *cobra.Command {
 	cmd.AddCommand(upgrade.Command())
 	cmd.AddCommand(indices.Command())
 	cmd.AddCommand(index.Command())
+	cmd.AddCommand(advisory.Command())
 	cmd.AddCommand(backup.Command())
 	cmd.AddCommand(cpe.Command())
 	cmd.AddCommand(purl.Command())

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -68,12 +68,33 @@ type Copy struct {
 	IndexErrorRequired    string
 	IndexFlagFullResponse string
 
+	AdvisoryShort       string
+	AdvisoryFeedsShort  string
+	AdvisoryFeedsSearch string
+	AdvisoryFeedsFull   string
+	AdvisoryListShort   string
+	AdvisoryBrowseShort string
+	AdvisoryFound       string
+
 	BackupShort            string
+	BackupLong             string
+	BackupListShort        string
+	BackupListFull         string
 	BackupUrlShort         string
 	BackupDownloadShort    string
 	BackupDownloadInfo     string
 	BackupDownloadProgress string
 	BackupDownloadComplete string
+
+	BackupAdvisoryShort         string
+	BackupAdvisoryOverwrite     string
+	BackupAdvisoryListShort     string
+	BackupAdvisoryListFull      string
+	BackupAdvisoryUrlShort      string
+	BackupAdvisoryDownloadShort string
+	BackupAdvisoryDownloadInfo  string
+	BackupAdvisoryErrorRequired string
+	BackupAdvisoryUnavailable   string
 
 	CpeShort               string
 	CpeExample             string
@@ -231,13 +252,39 @@ var En = Copy{
 	IndexErrorRequired:    "index name is required",
 	IndexFlagFullResponse: "Output full response",
 
-	BackupShort:         "Download a backup of a specified index",
+	AdvisoryShort:       "Query advisories in CVE Record Format 5.2 (api /v4)",
+	AdvisoryFeedsShort:  "List the advisory feeds available to filter by (GET /v4/advisory/list)",
+	AdvisoryFeedsSearch: "Listing %d advisory feeds searching for \"%s\"",
+	AdvisoryFeedsFull:   "Listing %d advisory feeds",
+	AdvisoryListShort:   "List advisory records (GET /v4/advisory)",
+	AdvisoryBrowseShort: "Browse advisory records interactively (GET /v4/advisory)",
+	AdvisoryFound:       "%d of %d advisory records",
+
+	BackupShort: "Fetch or download a bulk archive",
+	BackupLong: heredoc.Doc(`
+		Fetch or download a bulk archive.
+
+		  backup url|download <index>           v3, the index's native records
+		  backup advisory url|download <feed>   v4, CVE 5.2 records, one per CVE
+	`),
+	BackupListShort:     "List indices that have a backup available",
+	BackupListFull:      "Listing %d backups",
 	BackupUrlShort:      "Get the temporary signed URL of the backup of an index",
 	BackupDownloadShort: "Download the backup of an index",
 
 	BackupDownloadInfo:     "Downloading backup of %s, created on %s",
 	BackupDownloadProgress: "Downloading backup as %s",
 	BackupDownloadComplete: "Backup downloaded successfully",
+
+	BackupAdvisoryShort:         "Download a v4 advisory feed backup",
+	BackupAdvisoryOverwrite:     "%s has no timestamp in its name; a repeat download replaces it in place",
+	BackupAdvisoryListShort:     "List advisory feeds that have a backup available (GET /v4/backup)",
+	BackupAdvisoryListFull:      "Listing %d advisory feed backups",
+	BackupAdvisoryUrlShort:      "Get the temporary signed URL of an advisory feed backup (GET /v4/backup/{feed})",
+	BackupAdvisoryDownloadShort: "Download an advisory feed backup (GET /v4/backup/{feed})",
+	BackupAdvisoryDownloadInfo:  "Downloading advisory feed backup of %s",
+	BackupAdvisoryErrorRequired: "feed name is required",
+	BackupAdvisoryUnavailable:   "no backup is currently available for feed '%s'",
 
 	CpeShort:               "Look up a specified cpe for any related CVEs",
 	CpeExample:             "vulncheck cpe \"%s\"",

--- a/pkg/sdk/advisory.go
+++ b/pkg/sdk/advisory.go
@@ -1,0 +1,474 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultAdvisoryLimit is the page size /v4/advisory applies when the
+	// caller sends no limit. We mirror it locally so the result-window guard
+	// below computes the same window the API would.
+	DefaultAdvisoryLimit = 10
+
+	// MaxAdvisoryLimit is the largest page size the API accepts; anything
+	// higher is rejected with HTTP 400.
+	MaxAdvisoryLimit = 100
+
+	// maxAdvisoryWindow is OpenSearch's result window. Offset paging past it
+	// fails with HTTP 503 wrapping an OpenSearch "Result window is too large"
+	// 400, so we refuse the request rather than let that surface.
+	maxAdvisoryWindow = 10000
+)
+
+// AdvisoryQueryParameters is the CLOSED set of parameters /v4/advisory accepts.
+//
+// The json tags name the wire parameters for reference only -- encoding goes
+// through setAdvisoryQueryParameters, which is authoritative. Changing a tag
+// here changes nothing that reaches the API.
+//
+// It is closed by construction on purpose: the API returns HTTP 200 with zero
+// results for any parameter it does not recognise, rather than an error. Adding
+// a field here without a matching API parameter silently empties every response
+// that uses it.
+type AdvisoryQueryParameters struct {
+	// FILTERS
+	Name            string `json:"name"` // advisory feed name; exposed as --feed
+	CveID           string `json:"cve_id"`
+	Vendor          string `json:"vendor"`
+	Product         string `json:"product"`
+	Platform        string `json:"platform"`
+	Version         string `json:"version"`
+	CPE             string `json:"cpe"`
+	PackageName     string `json:"package_name"`
+	PURL            string `json:"purl"`
+	ReferenceURL    string `json:"reference_url"`
+	ReferenceTag    string `json:"reference_tag"`
+	DescriptionLang string `json:"description_lang"`
+	UpdatedAfter    string `json:"updatedAfter"`
+	UpdatedBefore   string `json:"updatedBefore"`
+
+	// PAGINATION
+	Page        int    `json:"page"`
+	Limit       int    `json:"limit"`
+	StartCursor bool   `json:"start_cursor"`
+	Cursor      string `json:"cursor"`
+}
+
+// filters returns every filter value, so callers can tell a filtered query from
+// a whole-corpus one without enumerating the fields again.
+func (q AdvisoryQueryParameters) filters() []string {
+	return []string{
+		q.Name, q.CveID, q.Vendor, q.Product, q.Platform, q.Version, q.CPE,
+		q.PackageName, q.PURL, q.ReferenceURL, q.ReferenceTag,
+		q.DescriptionLang, q.UpdatedAfter, q.UpdatedBefore,
+	}
+}
+
+// HasFilter reports whether at least one filter is set.
+func (q AdvisoryQueryParameters) HasFilter() bool {
+	for _, f := range q.filters() {
+		if f != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate rejects requests the API would answer misleadingly rather than with
+// a useful error. Callers should run it before issuing a request; the request
+// methods run it again so a bad query can never reach the wire.
+func (q AdvisoryQueryParameters) Validate() error {
+	if !q.HasFilter() {
+		return fmt.Errorf("at least one filter is required; see 'vulncheck advisory list --help' " +
+			"for the available filters, or 'vulncheck advisory feeds' for feed names")
+	}
+	if q.Limit > MaxAdvisoryLimit {
+		return fmt.Errorf("limit must not exceed %d", MaxAdvisoryLimit)
+	}
+	if q.Limit < 0 || q.Page < 0 {
+		return fmt.Errorf("limit and page must not be negative")
+	}
+	if q.Page > 0 && (q.StartCursor || q.Cursor != "") {
+		return fmt.Errorf("page cannot be combined with cursor pagination; the API silently ignores page and returns the first page")
+	}
+
+	// The window guard has to substitute the API's own default, or the most
+	// likely way to trip the ceiling -- a large --page with no --limit --
+	// multiplies by zero and sails through to a 503.
+	limit := q.Limit
+	if limit == 0 {
+		limit = DefaultAdvisoryLimit
+	}
+	page := q.Page
+	if page == 0 {
+		page = 1
+	}
+	if page*limit > maxAdvisoryWindow {
+		return fmt.Errorf(
+			"page %d at limit %d exceeds the API's %d result window; page beyond it with "+
+				"--start-cursor and --cursor, or --all",
+			page, limit, maxAdvisoryWindow)
+	}
+	return nil
+}
+
+// setAdvisoryQueryParameters encodes q into query. Only the parameters the API
+// documents are ever added.
+func setAdvisoryQueryParameters(query url.Values, q AdvisoryQueryParameters) {
+	for key, value := range map[string]string{
+		"name":             q.Name,
+		"cve_id":           q.CveID,
+		"vendor":           q.Vendor,
+		"product":          q.Product,
+		"platform":         q.Platform,
+		"version":          q.Version,
+		"cpe":              q.CPE,
+		"package_name":     q.PackageName,
+		"purl":             q.PURL,
+		"reference_url":    q.ReferenceURL,
+		"reference_tag":    q.ReferenceTag,
+		"description_lang": q.DescriptionLang,
+		"updatedAfter":     q.UpdatedAfter,
+		"updatedBefore":    q.UpdatedBefore,
+	} {
+		if value != "" {
+			query.Add(key, value)
+		}
+	}
+
+	if q.Limit != 0 {
+		query.Add("limit", fmt.Sprintf("%d", q.Limit))
+	}
+	if q.Page != 0 {
+		query.Add("page", fmt.Sprintf("%d", q.Page))
+	}
+	// start_cursor activates on PRESENCE -- the API ignores the value, so
+	// sending start_cursor=false would still switch the response into cursor
+	// mode. It must be omitted entirely when false.
+	if q.StartCursor {
+		query.Add("start_cursor", "true")
+	}
+	if q.Cursor != "" {
+		query.Add("cursor", q.Cursor)
+		query.Del("start_cursor") // mutually exclusive; the cursor wins
+	}
+}
+
+type AdvisoryMeta struct {
+	Total      int    `json:"total"`
+	Page       int    `json:"page"`
+	Pages      int    `json:"pages"`
+	Limit      int    `json:"limit"`
+	Filtered   int    `json:"filtered"`
+	NextCursor string `json:"next_cursor"`
+}
+
+// AdvisoryResponse holds records as raw JSON.
+//
+// Every record is a CVE Record Format 5.2 document. The CLI emits them verbatim
+// for --json and reads only a handful of paths for the table, so typing the
+// payload would buy nothing and would couple the CLI to the API's OpenAPI
+// codegen. IndexResponse takes the same approach for /v3/index.
+type AdvisoryResponse struct {
+	Meta AdvisoryMeta      `json:"_meta"`
+	Data []json.RawMessage `json:"data"`
+}
+
+// GetAdvisories https://docs.vulncheck.com/api/v4/advisory
+func (c *Client) GetAdvisories(q AdvisoryQueryParameters) (responseJSON *AdvisoryResponse, err error) {
+	if err := q.Validate(); err != nil {
+		return nil, err
+	}
+
+	// c.Request reads c.Values but never resets them, and Query/Add append
+	// rather than replace -- a reused client would otherwise send the previous
+	// call's values alongside this one, and the API keys off the first.
+	c.Values = &url.Values{}
+	setAdvisoryQueryParameters(*c.Values, q)
+
+	resp, err := c.Request("GET", "/v4/advisory")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	_ = json.NewDecoder(LimitedBody(resp.Body)).Decode(&responseJSON)
+	return responseJSON, nil
+}
+
+// GetAllAdvisories walks every page via cursor pagination, returning the
+// combined records and the number of pages fetched.
+//
+// Cursor mode is the only way past the API's result window, and termination is
+// not signalled by an empty next_cursor -- it stays populated on the final page
+// of content. We stop on an empty page or a cursor that stops advancing.
+//
+// The page count is returned because it is the one fact about the walk that the
+// combined result cannot express; the per-page metadata is deliberately not,
+// since it describes a page the caller never sees.
+func (c *Client) GetAllAdvisories(q AdvisoryQueryParameters) ([]json.RawMessage, int, error) {
+	if err := q.Validate(); err != nil {
+		return nil, 0, err
+	}
+
+	q.Page = 0
+	q.Cursor = ""
+	q.StartCursor = true
+
+	// The page size is not observable in the combined result, so always walk at
+	// the maximum. Inheriting the API's default costs an order of magnitude in
+	// requests: when this was written, walking metasploit (~3k records) took
+	// 57.5s at limit 10 against 6.2s at limit 100.
+	q.Limit = MaxAdvisoryLimit
+
+	response, err := c.GetAdvisories(q)
+	if err != nil {
+		return nil, 0, err
+	}
+	if response == nil {
+		return []json.RawMessage{}, 0, nil
+	}
+
+	combined := append([]json.RawMessage{}, response.Data...)
+	pages := 1
+	cursor := response.Meta.NextCursor
+
+	for cursor != "" {
+		next := q
+		next.StartCursor = false
+		next.Cursor = cursor
+
+		page, err := c.GetAdvisories(next)
+		if err != nil {
+			return nil, 0, err
+		}
+		pages++
+		if page == nil || len(page.Data) == 0 {
+			break
+		}
+		combined = append(combined, page.Data...)
+		if page.Meta.NextCursor == cursor {
+			break
+		}
+		cursor = page.Meta.NextCursor
+	}
+
+	return combined, pages, nil
+}
+
+type AdvisoryFeedMeta struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+type AdvisoryFeedsResponse struct {
+	Data []AdvisoryFeedMeta `json:"data"`
+}
+
+// GetAdvisoryFeeds https://docs.vulncheck.com/api/v4/advisory
+//
+// Note the endpoint is /v4/advisory/list: in the API "list" means the catalogue
+// of feeds, not the records. The CLI spells this 'advisory feeds' so that
+// 'advisory list' can keep meaning what 'index list' means.
+func (c *Client) GetAdvisoryFeeds() (responseJSON *AdvisoryFeedsResponse, err error) {
+	resp, err := c.ResetQuery().Request("GET", "/v4/advisory/list")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	_ = json.NewDecoder(LimitedBody(resp.Body)).Decode(&responseJSON)
+	return responseJSON, nil
+}
+
+// Strings representation of the response
+func (r AdvisoryResponse) String() string {
+	return fmt.Sprintf("Meta: %v\nData: %v\n", r.Meta, r.Data)
+}
+
+// GetData returns the records, never nil, so an empty page marshals as [] and
+// not null. Callers pipe this straight to --json.
+func (r AdvisoryResponse) GetData() []json.RawMessage {
+	if r.Data == nil {
+		return []json.RawMessage{}
+	}
+	return r.Data
+}
+
+// Strings representation of the response
+func (r AdvisoryFeedsResponse) String() string {
+	return fmt.Sprintf("Data: %v\n", r.Data)
+}
+
+// GetData - Returns the data from the response
+func (r AdvisoryFeedsResponse) GetData() []AdvisoryFeedMeta {
+	return r.Data
+}
+
+// maxAdvisoryTitle bounds the title column so one verbose feed cannot wreck the
+// table layout for every other row.
+const maxAdvisoryTitle = 72
+
+// AdvisoryRecordView is the flattened projection of a CVE Record Format 5.2
+// document that the table renderer needs.
+//
+// It is decoded separately from the raw record so that --json keeps emitting the
+// API's payload untouched. Every field under containers.cna is optional -- epss
+// records carry an empty title and nothing but metrics, ncsc-cves carry only a
+// title and references -- so each value falls back to a zero rather than
+// assuming a shape.
+type AdvisoryRecordView struct {
+	Feed       string
+	CveID      string
+	Title      string
+	CVSS       string
+	Affected   int
+	References int
+	Updated    string
+}
+
+type advisoryCVSS struct {
+	BaseScore float64 `json:"baseScore"`
+}
+
+// advisoryMetric is one entry in containers.cna.metrics. Non-CVSS metrics --
+// EPSS and other vendor blobs arrive under "other" -- decode to a zero value
+// and carry no base score.
+type advisoryMetric struct {
+	CvssV40 *advisoryCVSS `json:"cvssV4_0"`
+	CvssV31 *advisoryCVSS `json:"cvssV3_1"`
+	CvssV30 *advisoryCVSS `json:"cvssV3_0"`
+	CvssV20 *advisoryCVSS `json:"cvssV2_0"`
+}
+
+// bestCVSS returns the base score from the newest CVSS version present anywhere
+// in the slice.
+//
+// The version preference has to be applied across the whole slice, not within
+// one entry: CVE 5.x puts each version in its own metric object, so a record
+// carrying both v3.0 and v3.1 has two entries. Taking the maximum instead
+// renders a superseded score: CVE-2019-13548 in cisa-csaf was observed carrying
+// v3.0 10 alongside v3.1 9.8, where 9.8 is the authoritative one. Within a
+// single version, the highest score wins.
+func bestCVSS(metrics []advisoryMetric) (float64, bool) {
+	for _, ofVersion := range []func(advisoryMetric) *advisoryCVSS{
+		func(m advisoryMetric) *advisoryCVSS { return m.CvssV40 },
+		func(m advisoryMetric) *advisoryCVSS { return m.CvssV31 },
+		func(m advisoryMetric) *advisoryCVSS { return m.CvssV30 },
+		func(m advisoryMetric) *advisoryCVSS { return m.CvssV20 },
+	} {
+		best, found := 0.0, false
+		for _, m := range metrics {
+			if c := ofVersion(m); c != nil && (!found || c.BaseScore > best) {
+				best, found = c.BaseScore, true
+			}
+		}
+		if found {
+			return best, true
+		}
+	}
+	return 0, false
+}
+
+type advisoryRecordWire struct {
+	CveMetadata struct {
+		CveID         string `json:"cveId"`
+		DatePublished string `json:"datePublished"`
+		DateUpdated   string `json:"dateUpdated"`
+	} `json:"cveMetadata"`
+	Containers struct {
+		Cna struct {
+			ProviderMetadata struct {
+				ShortName   string `json:"shortName"`
+				DateUpdated string `json:"dateUpdated"`
+			} `json:"providerMetadata"`
+			Title        string `json:"title"`
+			Descriptions []struct {
+				Value string `json:"value"`
+			} `json:"descriptions"`
+			Affected   []json.RawMessage `json:"affected"`
+			References []json.RawMessage `json:"references"`
+			Metrics    []advisoryMetric  `json:"metrics"`
+		} `json:"cna"`
+	} `json:"containers"`
+}
+
+// ParseAdvisoryRecords projects raw records for display. Records that cannot be
+// decoded are skipped rather than failing the whole page: the table is a
+// convenience view, and --json still carries everything.
+func ParseAdvisoryRecords(records []json.RawMessage) []AdvisoryRecordView {
+	views := make([]AdvisoryRecordView, 0, len(records))
+	for _, raw := range records {
+		var wire advisoryRecordWire
+		if err := json.Unmarshal(raw, &wire); err != nil {
+			continue
+		}
+		cna := wire.Containers.Cna
+
+		title := cna.Title
+		if title == "" {
+			for _, d := range cna.Descriptions {
+				if d.Value != "" {
+					title = d.Value
+					break
+				}
+			}
+		}
+
+		updated := wire.CveMetadata.DateUpdated
+		if updated == "" {
+			updated = wire.CveMetadata.DatePublished
+		}
+		if updated == "" {
+			updated = cna.ProviderMetadata.DateUpdated
+		}
+
+		cvss := ""
+		if score, ok := bestCVSS(cna.Metrics); ok {
+			cvss = strconv.FormatFloat(score, 'f', -1, 64)
+		}
+
+		views = append(views, AdvisoryRecordView{
+			Feed:       cna.ProviderMetadata.ShortName,
+			CveID:      wire.CveMetadata.CveID,
+			Title:      truncateTitle(title, maxAdvisoryTitle),
+			CVSS:       cvss,
+			Affected:   len(cna.Affected),
+			References: len(cna.References),
+			Updated:    ShortDate(updated),
+		})
+	}
+	return views
+}
+
+// truncateTitle shortens on rune boundaries so multi-byte titles (jvndb and bdu
+// are not ASCII) are not cut mid-character.
+func truncateTitle(s string, limit int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	return string(runes[:limit-1]) + "…"
+}
+
+// ShortDate trims an RFC3339 timestamp to its date. Feeds are inconsistent
+// about precision and offset, so anything unparseable is passed through
+// untouched.
+func ShortDate(value string) string {
+	if value == "" {
+		return ""
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t.Format("2006-01-02")
+	}
+	if len(value) >= 10 {
+		return value[:10]
+	}
+	return value
+}

--- a/pkg/sdk/advisory.go
+++ b/pkg/sdk/advisory.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -197,16 +198,29 @@ func (c *Client) GetAdvisories(q AdvisoryQueryParameters) (responseJSON *Advisor
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	_ = json.NewDecoder(LimitedBody(resp.Body)).Decode(&responseJSON)
+	// A decode failure is the only evidence that the body was not the one we
+	// asked for. Discarding it -- as the v3 methods do -- leaves a truncated or
+	// tampered response indistinguishable from "no matches", which is the same
+	// silent zero this package refuses elsewhere.
+	if err := json.NewDecoder(LimitedBody(resp.Body)).Decode(&responseJSON); err != nil {
+		return nil, fmt.Errorf("decoding /v4/advisory response: %w", err)
+	}
 	return responseJSON, nil
 }
+
+// ErrEmptyAdvisoryResponse reports a 200 whose body decoded cleanly to nothing
+// at all -- a literal `null`. It is never a legitimate empty result: the API
+// spells that {"data":[],"_meta":{...}}.
+var ErrEmptyAdvisoryResponse = errors.New("empty response from /v4/advisory")
 
 // GetAllAdvisories walks every page via cursor pagination, returning the
 // combined records and the number of pages fetched.
 //
 // Cursor mode is the only way past the API's result window, and termination is
 // not signalled by an empty next_cursor -- it stays populated on the final page
-// of content. We stop on an empty page or a cursor that stops advancing.
+// of content. We stop on an empty page or a cursor that stops advancing -- but
+// an *absent* page is a fault, not a stopping point, or a walk cut short by a
+// bad response would look like one that finished.
 //
 // The page count is returned because it is the one fact about the walk that the
 // combined result cannot express; the per-page metadata is deliberately not,
@@ -231,7 +245,7 @@ func (c *Client) GetAllAdvisories(q AdvisoryQueryParameters) ([]json.RawMessage,
 		return nil, 0, err
 	}
 	if response == nil {
-		return []json.RawMessage{}, 0, nil
+		return nil, 0, ErrEmptyAdvisoryResponse
 	}
 
 	combined := append([]json.RawMessage{}, response.Data...)
@@ -247,8 +261,11 @@ func (c *Client) GetAllAdvisories(q AdvisoryQueryParameters) ([]json.RawMessage,
 		if err != nil {
 			return nil, 0, err
 		}
+		if page == nil {
+			return nil, 0, ErrEmptyAdvisoryResponse
+		}
 		pages++
-		if page == nil || len(page.Data) == 0 {
+		if len(page.Data) == 0 {
 			break
 		}
 		combined = append(combined, page.Data...)

--- a/pkg/sdk/advisory_record_test.go
+++ b/pkg/sdk/advisory_record_test.go
@@ -1,0 +1,207 @@
+package sdk
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func metrics(t *testing.T, raw string) []advisoryMetric {
+	t.Helper()
+	var m []advisoryMetric
+	assert.NoError(t, json.Unmarshal([]byte(raw), &m))
+	return m
+}
+
+// CVE 5.x puts each CVSS version in its own metric object, so version
+// preference has to span the slice. Taking the maximum instead renders a
+// superseded score.
+func TestBestCVSSPrefersTheNewestVersionAcrossEntries(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   string
+		want  float64
+		found bool
+	}{
+		{
+			// The live regression: cisa-csaf CVE-2019-13548.
+			name:  "v3.1 supersedes a higher v3.0",
+			raw:   `[{"cvssV3_0":{"baseScore":10}},{"cvssV3_1":{"baseScore":9.8}}]`,
+			want:  9.8,
+			found: true,
+		},
+		{
+			name:  "v4.0 supersedes v3.1",
+			raw:   `[{"cvssV3_1":{"baseScore":9.8}},{"cvssV4_0":{"baseScore":6.1}}]`,
+			want:  6.1,
+			found: true,
+		},
+		{
+			name:  "order within the slice does not matter",
+			raw:   `[{"cvssV3_1":{"baseScore":9.8}},{"cvssV3_0":{"baseScore":10}}]`,
+			want:  9.8,
+			found: true,
+		},
+		{
+			name:  "highest wins within one version",
+			raw:   `[{"cvssV3_1":{"baseScore":4.3}},{"cvssV3_1":{"baseScore":7.5}}]`,
+			want:  7.5,
+			found: true,
+		},
+		{
+			name:  "falls back to v2.0 when it is all there is",
+			raw:   `[{"cvssV2_0":{"baseScore":10}}]`,
+			want:  10,
+			found: true,
+		},
+		{
+			name:  "epss carries no base score",
+			raw:   `[{"format":"EPSS","other":{"content":{"score":0.7525},"type":"epss"}}]`,
+			found: false,
+		},
+		{
+			name:  "no metrics at all",
+			raw:   `[]`,
+			found: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score, found := bestCVSS(metrics(t, tt.raw))
+			assert.Equal(t, tt.found, found)
+			if tt.found {
+				assert.Equal(t, tt.want, score)
+			}
+		})
+	}
+}
+
+func TestParseAdvisoryRecordsProjectsAFullRecord(t *testing.T) {
+	record := `{
+	  "dataType":"CVE_RECORD","dataVersion":"5.2",
+	  "cveMetadata":{"cveId":"CVE-2019-12255","dateUpdated":"2023-11-14T10:02:11.000Z","datePublished":"2019-08-09T00:00:00Z"},
+	  "containers":{"cna":{
+	    "providerMetadata":{"shortName":"siemens"},
+	    "title":"Urgent/11 TCP/IP Stack Vulnerabilities",
+	    "affected":[{"vendor":"Siemens"},{"vendor":"Siemens"}],
+	    "references":[{"url":"a"},{"url":"b"},{"url":"c"}],
+	    "metrics":[{"cvssV3_1":{"baseScore":9.8}}]
+	  }}
+	}`
+
+	views := ParseAdvisoryRecords([]json.RawMessage{json.RawMessage(record)})
+	assert.Len(t, views, 1)
+
+	v := views[0]
+	assert.Equal(t, "siemens", v.Feed)
+	assert.Equal(t, "CVE-2019-12255", v.CveID)
+	assert.Equal(t, "Urgent/11 TCP/IP Stack Vulnerabilities", v.Title)
+	assert.Equal(t, "9.8", v.CVSS)
+	assert.Equal(t, 2, v.Affected)
+	assert.Equal(t, 3, v.References)
+	assert.Equal(t, "2023-11-14", v.Updated)
+}
+
+// epss records have an empty title and nothing but metrics; ncsc-cves have only
+// a title and references. Every field has to survive being absent.
+func TestParseAdvisoryRecordsToleratesSparseRecords(t *testing.T) {
+	views := ParseAdvisoryRecords([]json.RawMessage{
+		json.RawMessage(`{"cveMetadata":{"cveId":"CVE-1"},"containers":{"cna":{"providerMetadata":{"shortName":"epss"},"title":"","metrics":[{"format":"EPSS"}]}}}`),
+		json.RawMessage(`{"cveMetadata":{"cveId":"CVE-2"},"containers":{"cna":{}}}`),
+		json.RawMessage(`{}`),
+	})
+
+	assert.Len(t, views, 3)
+	assert.Equal(t, "epss", views[0].Feed)
+	assert.Empty(t, views[0].Title)
+	assert.Empty(t, views[0].CVSS)
+	assert.Zero(t, views[0].Affected)
+	assert.Equal(t, "CVE-2", views[1].CveID)
+	assert.Empty(t, views[2].CveID)
+}
+
+// A title-less record falls back to its first non-empty description.
+func TestParseAdvisoryRecordsFallsBackToDescription(t *testing.T) {
+	views := ParseAdvisoryRecords([]json.RawMessage{
+		json.RawMessage(`{"containers":{"cna":{"descriptions":[{"value":""},{"value":"a directory traversal in tvs.php"}]}}}`),
+	})
+	assert.Equal(t, "a directory traversal in tvs.php", views[0].Title)
+}
+
+func TestParseAdvisoryRecordsUpdatedFallbackChain(t *testing.T) {
+	tests := []struct {
+		name   string
+		record string
+		want   string
+	}{
+		{
+			name:   "dateUpdated wins",
+			record: `{"cveMetadata":{"dateUpdated":"2023-11-14T00:00:00Z","datePublished":"2019-01-01T00:00:00Z"},"containers":{"cna":{"providerMetadata":{"dateUpdated":"2020-01-01T00:00:00Z"}}}}`,
+			want:   "2023-11-14",
+		},
+		{
+			name:   "datePublished next",
+			record: `{"cveMetadata":{"datePublished":"2019-01-01T00:00:00Z"},"containers":{"cna":{"providerMetadata":{"dateUpdated":"2020-01-01T00:00:00Z"}}}}`,
+			want:   "2019-01-01",
+		},
+		{
+			name:   "providerMetadata last",
+			record: `{"containers":{"cna":{"providerMetadata":{"dateUpdated":"2020-01-01T00:00:00Z"}}}}`,
+			want:   "2020-01-01",
+		},
+		{
+			name:   "nothing at all",
+			record: `{"containers":{"cna":{}}}`,
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			views := ParseAdvisoryRecords([]json.RawMessage{json.RawMessage(tt.record)})
+			assert.Equal(t, tt.want, views[0].Updated)
+		})
+	}
+}
+
+// A record that will not decode is skipped rather than failing the page: the
+// table is a convenience view and --json still carries everything.
+func TestParseAdvisoryRecordsSkipsUndecodableRecords(t *testing.T) {
+	views := ParseAdvisoryRecords([]json.RawMessage{
+		json.RawMessage(`{"cveMetadata":{"cveId":"CVE-1"}}`),
+		json.RawMessage(`not json`),
+		json.RawMessage(`{"cveMetadata":{"cveId":"CVE-2"}}`),
+	})
+	assert.Len(t, views, 2)
+	assert.Equal(t, "CVE-1", views[0].CveID)
+	assert.Equal(t, "CVE-2", views[1].CveID)
+}
+
+// jvndb and bdu titles are not ASCII, so truncation has to land on a rune
+// boundary or the cell contains a broken character.
+func TestTruncateTitleCutsOnRuneBoundaries(t *testing.T) {
+	long := strings.Repeat("脆", 100)
+	got := truncateTitle(long, maxAdvisoryTitle)
+
+	assert.Equal(t, maxAdvisoryTitle, len([]rune(got)))
+	assert.True(t, strings.HasSuffix(got, "…"))
+	assert.True(t, utf8.ValidString(got), "truncation must not split a rune")
+}
+
+func TestTruncateTitleCollapsesWhitespace(t *testing.T) {
+	assert.Equal(t, "a b c", truncateTitle("  a\n\tb   c  ", maxAdvisoryTitle))
+	assert.Equal(t, "short", truncateTitle("short", maxAdvisoryTitle))
+}
+
+func TestShortDate(t *testing.T) {
+	assert.Equal(t, "2026-09-02", ShortDate("2026-09-02T16:17:49Z"))
+	assert.Equal(t, "2026-09-02", ShortDate("2026-09-02T16:17:49.009938487Z"))
+	// Feeds are inconsistent about precision, so anything unparseable is
+	// passed through rather than dropped.
+	assert.Equal(t, "2026-09-02", ShortDate("2026-09-02"))
+	assert.Equal(t, "", ShortDate(""))
+	assert.Equal(t, "nonsense", ShortDate("nonsense"))
+}

--- a/pkg/sdk/advisory_test.go
+++ b/pkg/sdk/advisory_test.go
@@ -1,0 +1,271 @@
+package sdk
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// knownAdvisoryParams is every parameter /v4/advisory documents. The API answers
+// HTTP 200 with zero results for anything else, so a stray parameter is silent
+// data loss rather than an error -- this list is the guard against that.
+var knownAdvisoryParams = map[string]bool{
+	"name": true, "cve_id": true, "vendor": true, "product": true,
+	"platform": true, "version": true, "cpe": true, "package_name": true,
+	"purl": true, "reference_url": true, "reference_tag": true,
+	"description_lang": true, "updatedAfter": true, "updatedBefore": true,
+	"page": true, "limit": true, "start_cursor": true, "cursor": true,
+}
+
+func advisoryStub(t *testing.T, body string, seen *[]url.Values) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if seen != nil {
+			*seen = append(*seen, r.URL.Query())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+const emptyAdvisoryBody = `{"data":[],"_meta":{"total":0,"page":1,"pages":0,"limit":10,"filtered":0}}`
+
+func TestGetAdvisoriesSendsOnlyKnownParameters(t *testing.T) {
+	var seen []url.Values
+	srv := advisoryStub(t, emptyAdvisoryBody, &seen)
+
+	_, err := Connect(srv.URL, "tok").GetAdvisories(AdvisoryQueryParameters{
+		Name: "ghsa", CveID: "CVE-2019-12255", Vendor: "Siemens",
+		Product: "SIPROTEC", Platform: "linux", Version: "1.0",
+		CPE: "cpe:2.3:a:x:y", PackageName: "pkg", PURL: "pkg:npm/x",
+		ReferenceURL: "https://example.com", ReferenceTag: "patch",
+		DescriptionLang: "en", UpdatedAfter: "now-7d", UpdatedBefore: "now",
+		Limit: 50, Page: 2,
+	})
+	assert.NoError(t, err)
+	assert.Len(t, seen, 1)
+
+	var unknown []string
+	for key := range seen[0] {
+		if !knownAdvisoryParams[key] {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	assert.Empty(t, unknown, "unknown parameters silently zero the result set")
+
+	assert.Equal(t, "ghsa", seen[0].Get("name"))
+	assert.Equal(t, "CVE-2019-12255", seen[0].Get("cve_id"))
+	assert.Equal(t, "pkg", seen[0].Get("package_name"))
+	assert.Equal(t, "now-7d", seen[0].Get("updatedAfter"))
+	assert.Equal(t, "50", seen[0].Get("limit"))
+	assert.Equal(t, "2", seen[0].Get("page"))
+}
+
+// A reused client must not accumulate values: url.Values.Add appends, and the
+// API keys off the first occurrence of a repeated parameter.
+func TestGetAdvisoriesDoesNotAccumulateParametersAcrossCalls(t *testing.T) {
+	var seen []url.Values
+	srv := advisoryStub(t, emptyAdvisoryBody, &seen)
+	client := Connect(srv.URL, "tok")
+
+	_, err := client.GetAdvisories(AdvisoryQueryParameters{Name: "ghsa"})
+	assert.NoError(t, err)
+	_, err = client.GetAdvisories(AdvisoryQueryParameters{Name: "epss"})
+	assert.NoError(t, err)
+
+	assert.Len(t, seen, 2)
+	assert.Equal(t, []string{"epss"}, seen[1]["name"])
+}
+
+// start_cursor activates on presence -- the API ignores the value, so sending
+// start_cursor=false would still switch the response into cursor mode.
+func TestStartCursorIsOmittedWhenFalse(t *testing.T) {
+	var seen []url.Values
+	srv := advisoryStub(t, emptyAdvisoryBody, &seen)
+	client := Connect(srv.URL, "tok")
+
+	_, err := client.GetAdvisories(AdvisoryQueryParameters{Name: "ghsa", StartCursor: false})
+	assert.NoError(t, err)
+	_, hasKey := seen[0]["start_cursor"]
+	assert.False(t, hasKey, "start_cursor must be absent, not false")
+
+	_, err = client.GetAdvisories(AdvisoryQueryParameters{Name: "ghsa", StartCursor: true})
+	assert.NoError(t, err)
+	assert.Equal(t, "true", seen[1].Get("start_cursor"))
+}
+
+func TestCursorSupersedesStartCursor(t *testing.T) {
+	var seen []url.Values
+	srv := advisoryStub(t, emptyAdvisoryBody, &seen)
+
+	_, err := Connect(srv.URL, "tok").GetAdvisories(AdvisoryQueryParameters{
+		Name: "ghsa", StartCursor: true, Cursor: "abc",
+	})
+	assert.NoError(t, err)
+	_, hasKey := seen[0]["start_cursor"]
+	assert.False(t, hasKey)
+	assert.Equal(t, "abc", seen[0].Get("cursor"))
+}
+
+// Every rejected query must be rejected before a request is issued.
+func TestValidationRejectsBeforeAnyRequest(t *testing.T) {
+	tests := []struct {
+		name  string
+		query AdvisoryQueryParameters
+		want  string
+	}{
+		{
+			name:  "no filter would walk the whole corpus",
+			query: AdvisoryQueryParameters{Limit: 10},
+			want:  "at least one filter is required",
+		},
+		{
+			name:  "page with start_cursor is silently ignored by the API",
+			query: AdvisoryQueryParameters{Name: "ghsa", Page: 3, StartCursor: true},
+			want:  "cannot be combined with cursor pagination",
+		},
+		{
+			name:  "page with an explicit cursor",
+			query: AdvisoryQueryParameters{Name: "ghsa", Page: 3, Cursor: "abc"},
+			want:  "cannot be combined with cursor pagination",
+		},
+		{
+			name:  "limit above the API maximum",
+			query: AdvisoryQueryParameters{Name: "ghsa", Limit: 101},
+			want:  "must not exceed 100",
+		},
+		{
+			name:  "result window, explicit limit",
+			query: AdvisoryQueryParameters{Name: "ghsa", Limit: 100, Page: 101},
+			want:  "result window",
+		},
+		{
+			name:  "result window, small limit",
+			query: AdvisoryQueryParameters{Name: "ghsa", Limit: 1, Page: 10001},
+			want:  "result window",
+		},
+		{
+			// The likeliest way to trip the ceiling: without substituting the
+			// API's default of 10, page*limit is 0 and this sails through.
+			name:  "result window with limit unset",
+			query: AdvisoryQueryParameters{Name: "ghsa", Page: 1001},
+			want:  "result window",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests++
+				_, _ = fmt.Fprint(w, emptyAdvisoryBody)
+			}))
+			defer srv.Close()
+
+			_, err := Connect(srv.URL, "tok").GetAdvisories(tt.query)
+			assert.ErrorContains(t, err, tt.want)
+			assert.Zero(t, requests, "the guard must fire before any HTTP request")
+		})
+	}
+}
+
+func TestValidationAcceptsTheBoundaries(t *testing.T) {
+	assert.NoError(t, AdvisoryQueryParameters{Name: "ghsa", Limit: 100, Page: 100}.Validate())
+	assert.NoError(t, AdvisoryQueryParameters{Name: "ghsa", Limit: 10, Page: 1000}.Validate())
+	assert.NoError(t, AdvisoryQueryParameters{Name: "ghsa", Page: 1000}.Validate())
+	assert.NoError(t, AdvisoryQueryParameters{CveID: "CVE-2019-12255"}.Validate())
+}
+
+// next_cursor stays populated on the final page of content, so termination has
+// to come from an empty page. This mirrors the live 50/50/50/9/0 shape.
+func TestGetAllAdvisoriesWalksUntilAnEmptyPage(t *testing.T) {
+	pages := []string{
+		`{"data":[{"a":1},{"a":2}],"_meta":{"total":5,"next_cursor":"c1"}}`,
+		`{"data":[{"a":3},{"a":4}],"_meta":{"total":5,"next_cursor":"c2"}}`,
+		`{"data":[{"a":5}],"_meta":{"total":5,"next_cursor":"c3"}}`,
+		`{"data":[],"_meta":{"total":5,"next_cursor":"c3"}}`,
+	}
+	var seen []url.Values
+	call := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.URL.Query())
+		body := `{"data":[],"_meta":{}}`
+		if call < len(pages) {
+			body = pages[call]
+		}
+		call++
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	records, walked, err := Connect(srv.URL, "tok").GetAllAdvisories(AdvisoryQueryParameters{Name: "sigmahq-sigma-rules", Limit: 2})
+	assert.NoError(t, err)
+	assert.Len(t, records, 5)
+	// Every request counts, terminator included: the point of the number is
+	// what the walk cost.
+	assert.Equal(t, 4, walked, "three content pages plus the empty terminator")
+	assert.Len(t, seen, 4)
+
+	assert.Equal(t, "true", seen[0].Get("start_cursor"))
+	assert.Equal(t, "c1", seen[1].Get("cursor"))
+	_, hasKey := seen[1]["start_cursor"]
+	assert.False(t, hasKey, "start_cursor must not ride along with a cursor")
+}
+
+// The page size is invisible in the combined output, so a walk must always use
+// the maximum. Inheriting the API default of 10 costs an order of magnitude in
+// requests -- measured at 57.5s vs 6.2s over 3,167 records.
+func TestGetAllAdvisoriesAlwaysWalksAtTheMaximumPageSize(t *testing.T) {
+	for _, requested := range []int{0, 2, 100} {
+		var seen []url.Values
+		srv := advisoryStub(t, `{"data":[],"_meta":{}}`, &seen)
+
+		_, _, err := Connect(srv.URL, "tok").GetAllAdvisories(AdvisoryQueryParameters{
+			Name: "ghsa", Limit: requested,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "100", seen[0].Get("limit"), "requested limit %d", requested)
+	}
+}
+
+// A cursor that stops advancing must terminate the walk rather than loop.
+func TestGetAllAdvisoriesStopsOnARepeatedCursor(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = fmt.Fprint(w, `{"data":[{"a":1}],"_meta":{"next_cursor":"stuck"}}`)
+	}))
+	defer srv.Close()
+
+	records, _, err := Connect(srv.URL, "tok").GetAllAdvisories(AdvisoryQueryParameters{Name: "ghsa"})
+	assert.NoError(t, err)
+	assert.Len(t, records, 2)
+	assert.Equal(t, 2, calls)
+}
+
+func TestGetAdvisoryFeedsDecodesTheCatalogue(t *testing.T) {
+	srv := advisoryStub(t, `{"data":[{"name":"epss","href":"http://api.vulncheck.com/v4/advisory?name=epss"},{"name":"ghsa","href":"x"}]}`, nil)
+
+	response, err := Connect(srv.URL, "tok").GetAdvisoryFeeds()
+	assert.NoError(t, err)
+	assert.Len(t, response.GetData(), 2)
+	assert.Equal(t, "epss", response.GetData()[0].Name)
+}
+
+func TestAdvisoryResponseDecodesMeta(t *testing.T) {
+	srv := advisoryStub(t, `{"data":[{"dataType":"CVE_RECORD"}],"_meta":{"total":39,"page":1,"pages":1,"limit":100,"filtered":39,"next_cursor":"abc"}}`, nil)
+
+	response, err := Connect(srv.URL, "tok").GetAdvisories(AdvisoryQueryParameters{CveID: "CVE-2019-12255"})
+	assert.NoError(t, err)
+	assert.Equal(t, 39, response.Meta.Total)
+	assert.Equal(t, "abc", response.Meta.NextCursor)
+	assert.Len(t, response.GetData(), 1)
+}

--- a/pkg/sdk/advisory_test.go
+++ b/pkg/sdk/advisory_test.go
@@ -251,6 +251,70 @@ func TestGetAllAdvisoriesStopsOnARepeatedCursor(t *testing.T) {
 	assert.Equal(t, 2, calls)
 }
 
+// A body that does not decode is the only evidence that the response was not
+// the one we asked for. Returning it as a nil result with a nil error would
+// make a truncated page indistinguishable from "no matches".
+func TestGetAdvisoriesSurfacesADecodeFailure(t *testing.T) {
+	srv := advisoryStub(t, `{"data":[{"a":1}`, nil)
+
+	response, err := Connect(srv.URL, "tok").GetAdvisories(AdvisoryQueryParameters{Name: "ghsa"})
+	assert.Nil(t, response)
+	assert.ErrorContains(t, err, "decoding /v4/advisory response")
+}
+
+// --all is the one path where a broken response used to be invisible: the walk
+// read a nil page as end-of-walk and reported a clean run of zero records.
+func TestGetAllAdvisoriesFailsOnATruncatedFirstPage(t *testing.T) {
+	srv := advisoryStub(t, `{"data":[{"a":1}`, nil)
+
+	records, walked, err := Connect(srv.URL, "tok").GetAllAdvisories(AdvisoryQueryParameters{Name: "ghsa"})
+	assert.ErrorContains(t, err, "decoding /v4/advisory response")
+	assert.Nil(t, records)
+	assert.Zero(t, walked)
+}
+
+// Mid-walk the stakes are higher still: page 1 decoded, so without this the
+// caller receives a genuine but silently incomplete slice.
+func TestGetAllAdvisoriesFailsOnATruncatedPageMidWalk(t *testing.T) {
+	call := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		call++
+		if call == 1 {
+			_, _ = fmt.Fprint(w, `{"data":[{"a":1}],"_meta":{"next_cursor":"c1"}}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"data":[{"a":2}`)
+	}))
+	defer srv.Close()
+
+	records, walked, err := Connect(srv.URL, "tok").GetAllAdvisories(AdvisoryQueryParameters{Name: "ghsa"})
+	assert.ErrorContains(t, err, "decoding /v4/advisory response")
+	assert.Nil(t, records, "a partial walk must not be returned as a complete one")
+	assert.Zero(t, walked)
+}
+
+// A literal `null` decodes cleanly to no response at all. It is never a real
+// empty result -- the API spells that {"data":[],"_meta":{...}}.
+func TestGetAllAdvisoriesFailsOnANullBody(t *testing.T) {
+	for _, page := range []string{"first", "mid-walk"} {
+		call := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			call++
+			if page == "mid-walk" && call == 1 {
+				_, _ = fmt.Fprint(w, `{"data":[{"a":1}],"_meta":{"next_cursor":"c1"}}`)
+				return
+			}
+			_, _ = fmt.Fprint(w, `null`)
+		}))
+
+		records, walked, err := Connect(srv.URL, "tok").GetAllAdvisories(AdvisoryQueryParameters{Name: "ghsa"})
+		assert.ErrorIs(t, err, ErrEmptyAdvisoryResponse, "%s page", page)
+		assert.Nil(t, records)
+		assert.Zero(t, walked)
+		srv.Close()
+	}
+}
+
 func TestGetAdvisoryFeedsDecodesTheCatalogue(t *testing.T) {
 	srv := advisoryStub(t, `{"data":[{"name":"epss","href":"http://api.vulncheck.com/v4/advisory?name=epss"},{"name":"ghsa","href":"x"}]}`, nil)
 

--- a/pkg/sdk/backup_advisory.go
+++ b/pkg/sdk/backup_advisory.go
@@ -1,0 +1,92 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+type AdvisoryBackupMeta struct {
+	Name            string `json:"name"`
+	Href            string `json:"href"`
+	Available       bool   `json:"available"`
+	BackupWrittenAt string `json:"backup_written_at"`
+}
+
+type AdvisoryBackupsResponse struct {
+	Data []AdvisoryBackupMeta `json:"data"`
+}
+
+// AdvisoryBackup is the /v4/backup/{feed} payload.
+//
+// Unlike /v3/backup/{index} this is a flat object rather than a data array, it
+// carries no filename or date_added (backup_written_at lives on the list
+// endpoint instead), there is no plain "url" field, and url_ttl_minutes is a
+// number here where v3 sends a string.
+type AdvisoryBackup struct {
+	Feed            string `json:"feed"`
+	Available       bool   `json:"available"`
+	URLMrap         string `json:"url_mrap"`
+	URLUsEast1      string `json:"url_us-east-1"`
+	URLEuWest2      string `json:"url_eu-west-2"`
+	URLApSoutheast2 string `json:"url_ap-southeast-2"`
+	URLExpires      string `json:"url_expires"`
+	URLTTLMinutes   int    `json:"url_ttl_minutes"`
+	SHA256          string `json:"sha256"`
+
+	// URL is not sent by the API, which offers only the regional variants
+	// above. It is resolved on decode so that `jq -r .url` works identically
+	// against a v3 and a v4 backup payload.
+	URL string `json:"url"`
+}
+
+// resolveURL picks the download URL, preferring the multi-region access point
+// and falling back to a regional bucket if it is absent.
+func (b AdvisoryBackup) resolveURL() string {
+	for _, u := range []string{b.URLMrap, b.URLUsEast1, b.URLEuWest2, b.URLApSoutheast2} {
+		if u != "" {
+			return u
+		}
+	}
+	return ""
+}
+
+// GetAdvisoryBackups https://docs.vulncheck.com/api/v4/backup
+func (c *Client) GetAdvisoryBackups() (responseJSON *AdvisoryBackupsResponse, err error) {
+	resp, err := c.ResetQuery().Request("GET", "/v4/backup")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	_ = json.NewDecoder(LimitedBody(resp.Body)).Decode(&responseJSON)
+	return responseJSON, nil
+}
+
+// GetAdvisoryBackup https://docs.vulncheck.com/api/v4/backup
+//
+// PathEscape, not QueryEscape: the feed is a path segment, and QueryEscape
+// encodes a space as "+" rather than "%20".
+func (c *Client) GetAdvisoryBackup(feed string) (responseJSON *AdvisoryBackup, err error) {
+	resp, err := c.ResetQuery().Request("GET", "/v4/backup/"+url.PathEscape(feed))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	_ = json.NewDecoder(LimitedBody(resp.Body)).Decode(&responseJSON)
+	if responseJSON != nil {
+		responseJSON.URL = responseJSON.resolveURL()
+	}
+	return responseJSON, nil
+}
+
+// Strings representation of the response
+func (r AdvisoryBackupsResponse) String() string {
+	return fmt.Sprintf("Data: %v\n", r.Data)
+}
+
+// GetData - Returns the data from the response
+func (r AdvisoryBackupsResponse) GetData() []AdvisoryBackupMeta {
+	return r.Data
+}

--- a/pkg/sdk/backup_advisory_test.go
+++ b/pkg/sdk/backup_advisory_test.go
@@ -1,0 +1,84 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAdvisoryBackupsDecodesTheFeedList(t *testing.T) {
+	body := `{"data":[{"name":"epss","href":"https://api.vulncheck.com/v4/backup/epss","available":true,"backup_written_at":"2026-09-02T16:17:49Z"},{"name":"ghsa","href":"x","available":false,"backup_written_at":""}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	response, err := Connect(srv.URL, "tok").GetAdvisoryBackups()
+	assert.NoError(t, err)
+	assert.Len(t, response.GetData(), 2)
+	assert.Equal(t, "epss", response.GetData()[0].Name)
+	assert.True(t, response.GetData()[0].Available)
+	assert.Equal(t, "2026-09-02T16:17:49Z", response.GetData()[0].BackupWrittenAt)
+	assert.False(t, response.GetData()[1].Available)
+}
+
+// /v4/backup/{feed} is a flat object with no data array, no filename and no
+// date_added, and url_ttl_minutes is a number where v3 sends a string.
+func TestGetAdvisoryBackupDecodesTheFlatPayload(t *testing.T) {
+	body := `{"feed":"ghsa","available":true,"url_mrap":"https://mrap/ghsa.zip","url_us-east-1":"https://use1/ghsa.zip","url_eu-west-2":"https://euw2/ghsa.zip","url_ap-southeast-2":"https://apse2/ghsa.zip","url_expires":"2026-09-02T16:42:21Z","url_ttl_minutes":15,"sha256":"01133e67"}`
+	var path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		_, _ = fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	backup, err := Connect(srv.URL, "tok").GetAdvisoryBackup("ghsa")
+	assert.NoError(t, err)
+	assert.Equal(t, "/v4/backup/ghsa", path)
+	assert.Equal(t, "ghsa", backup.Feed)
+	assert.True(t, backup.Available)
+	assert.Equal(t, 15, backup.URLTTLMinutes)
+	assert.Equal(t, "01133e67", backup.SHA256)
+	assert.Equal(t, "https://mrap/ghsa.zip", backup.URL)
+}
+
+func TestAdvisoryBackupURLFallsBackThroughRegions(t *testing.T) {
+	assert.Equal(t, "https://use1/x.zip", AdvisoryBackup{URLUsEast1: "https://use1/x.zip"}.resolveURL())
+	assert.Equal(t, "https://euw2/x.zip", AdvisoryBackup{URLEuWest2: "https://euw2/x.zip"}.resolveURL())
+	assert.Empty(t, AdvisoryBackup{}.resolveURL())
+}
+
+// The API sends only the regional variants; url is resolved on decode so that
+// `jq -r .url` works against a v3 and a v4 payload alike.
+func TestAdvisoryBackupExposesAPlainURLField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"feed":"ghsa","available":true,"url_us-east-1":"https://use1/ghsa.zip"}`)
+	}))
+	defer srv.Close()
+
+	backup, err := Connect(srv.URL, "tok").GetAdvisoryBackup("ghsa")
+	assert.NoError(t, err)
+
+	encoded, err := json.Marshal(backup)
+	assert.NoError(t, err)
+	assert.Contains(t, string(encoded), `"url":"https://use1/ghsa.zip"`)
+}
+
+// PathEscape, not QueryEscape: a space in a path segment is %20, not "+".
+func TestGetAdvisoryBackupEscapesTheFeedAsAPathSegment(t *testing.T) {
+	var path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.EscapedPath()
+		_, _ = fmt.Fprint(w, `{"feed":"x"}`)
+	}))
+	defer srv.Close()
+
+	_, err := Connect(srv.URL, "tok").GetAdvisoryBackup("a b")
+	assert.NoError(t, err)
+	assert.Equal(t, "/v4/backup/a%20b", path)
+}

--- a/pkg/sdk/utils.go
+++ b/pkg/sdk/utils.go
@@ -5,6 +5,40 @@ import (
 	"net/http"
 )
 
+// UnmarshalJSON decodes both error shapes: v3's {"error": true, "errors": [...]}
+// and v4's {"error": "<message>"}. The string form is promoted into Errors
+// because that is the only field defaultMessageFor reads.
+func (m *MetaError) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Error  json.RawMessage `json:"error"`
+		Errors []string        `json:"errors"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	m.Errors = raw.Errors
+
+	if len(raw.Error) == 0 {
+		return nil
+	}
+
+	var flag bool
+	if err := json.Unmarshal(raw.Error, &flag); err == nil {
+		m.Error = flag
+		return nil
+	}
+
+	var message string
+	if err := json.Unmarshal(raw.Error, &message); err == nil && message != "" {
+		m.Error = true
+		if len(m.Errors) == 0 {
+			m.Errors = []string{message}
+		}
+	}
+	return nil
+}
+
 // MetaError is a struct that represents the error response from the API
 func handleErrorResponse(resp *http.Response) error {
 	var metaError MetaError

--- a/pkg/sdk/utils_test.go
+++ b/pkg/sdk/utils_test.go
@@ -39,3 +39,78 @@ func TestHandleErrorResponse(t *testing.T) {
 		}
 	}
 }
+
+// The v4 endpoints send {"error": "<message>"} where v3 sends
+// {"error": true, "errors": [...]}. The string form must be promoted into
+// Errors, because that is the only field the error classifier reads -- decoding
+// it anywhere else leaves the user with no message at all.
+func TestMetaErrorDecodesBothErrorShapes(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantFlag   bool
+		wantErrors []string
+	}{
+		{
+			name:       "v3 shape",
+			body:       `{"error":true,"errors":["unauthorized"]}`,
+			wantFlag:   true,
+			wantErrors: []string{"unauthorized"},
+		},
+		{
+			name:       "v3 shape, entitlement",
+			body:       `{"error":true,"errors":["This endpoint requires a valid trial or paid subscription"]}`,
+			wantFlag:   true,
+			wantErrors: []string{"This endpoint requires a valid trial or paid subscription"},
+		},
+		{
+			name:       "v4 string shape, backup feed not found",
+			body:       `{"error":"feed not found: \"nosuchfeed\""}`,
+			wantFlag:   true,
+			wantErrors: []string{`feed not found: "nosuchfeed"`},
+		},
+		{
+			name:       "v4 string shape, opensearch window",
+			body:       `{"error":"failed to query data-source: opensearch response: status 400"}`,
+			wantFlag:   true,
+			wantErrors: []string{"failed to query data-source: opensearch response: status 400"},
+		},
+		{
+			name:       "no error field",
+			body:       `{}`,
+			wantFlag:   false,
+			wantErrors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var metaError MetaError
+			if err := json.Unmarshal([]byte(tt.body), &metaError); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if metaError.Error != tt.wantFlag {
+				t.Errorf("Error = %v, want %v", metaError.Error, tt.wantFlag)
+			}
+			if len(metaError.Errors) != len(tt.wantErrors) {
+				t.Fatalf("Errors = %#v, want %#v", metaError.Errors, tt.wantErrors)
+			}
+			for i, want := range tt.wantErrors {
+				if metaError.Errors[i] != want {
+					t.Errorf("Errors[%d] = %q, want %q", i, metaError.Errors[i], want)
+				}
+			}
+		})
+	}
+}
+
+// An explicit errors array wins over the string form rather than being replaced.
+func TestMetaErrorKeepsAnExplicitErrorsArray(t *testing.T) {
+	var metaError MetaError
+	if err := json.Unmarshal([]byte(`{"error":"ignored","errors":["real message"]}`), &metaError); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(metaError.Errors) != 1 || metaError.Errors[0] != "real message" {
+		t.Errorf("Errors = %#v, want [real message]", metaError.Errors)
+	}
+}

--- a/pkg/ui/advisory.go
+++ b/pkg/ui/advisory.go
@@ -1,0 +1,146 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	ltable "github.com/charmbracelet/lipgloss/table"
+	"github.com/vulncheck-oss/cli/pkg/sdk"
+)
+
+// AdvisoryFeedRow pairs a feed with its backup availability.
+//
+// The v4 feed list is only {name, href} -- there is no description, which is
+// the column that makes the v3 index catalogue worth rendering -- so the
+// backup columns are what give this table something to say.
+type AdvisoryFeedRow struct {
+	Name string `json:"name"`
+	// Href is carried through from the API payload rather than dropped, so this
+	// row stays a superset of what /v4/advisory/list returned.
+	Href string `json:"href"`
+	// Available is nil when the backup join was unavailable, so a consumer can
+	// tell "no backup" apart from "we could not find out".
+	// No omitempty on either: v4 backup is a separate entitlement from v4
+	// advisory, so omitting them would make the JSON shape depend on the
+	// caller's token tier. The keys are always present, and a null Available
+	// means the backup list could not be read.
+	Available       *bool  `json:"available"`
+	BackupWrittenAt string `json:"backup_written_at"`
+}
+
+// AdvisoryFeeds joins the feed catalogue with backup availability.
+//
+// backups may be nil: v4 backup is a separate entitlement from v4 advisory (a
+// trial grants the latter but not the former), so the join is best-effort and
+// the caller passes nil when /v4/backup was refused. Rendering then degrades to
+// the name column rather than failing a discovery command the user is entitled
+// to run.
+func AdvisoryFeeds(feeds []sdk.AdvisoryFeedMeta, backups []sdk.AdvisoryBackupMeta, search string) []AdvisoryFeedRow {
+	available := make(map[string]sdk.AdvisoryBackupMeta, len(backups))
+	for _, b := range backups {
+		available[b.Name] = b
+	}
+
+	rows := make([]AdvisoryFeedRow, 0, len(feeds))
+	for _, feed := range feeds {
+		if search != "" && !strings.Contains(feed.Name, search) {
+			continue
+		}
+		row := AdvisoryFeedRow{Name: feed.Name, Href: feed.Href}
+		if backup, ok := available[feed.Name]; ok {
+			hasBackup := backup.Available
+			row.Available = &hasBackup
+			row.BackupWrittenAt = sdk.ShortDate(backup.BackupWrittenAt)
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func AdvisoryFeedsList(rows []AdvisoryFeedRow, withBackups bool) error {
+	headers := []string{"Name"}
+	if withBackups {
+		headers = append(headers, "Backup", "Written")
+	}
+
+	t := ltable.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("#6667ab"))).
+		Headers(headers...).Width(TermWidth())
+
+	for _, row := range rows {
+		if withBackups {
+			t.Row(row.Name, yesNo(row.Available), row.BackupWrittenAt)
+			continue
+		}
+		t.Row(row.Name)
+	}
+
+	fmt.Println(t)
+	return nil
+}
+
+func AdvisoryList(records []sdk.AdvisoryRecordView) error {
+	t := ltable.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("#6667ab"))).
+		Headers("Feed", "CVE", "Title", "CVSS", "Affected", "Refs", "Updated").Width(TermWidth())
+
+	for _, r := range records {
+		t.Row(r.Feed, r.CveID, r.Title, r.CVSS, strconv.Itoa(r.Affected), strconv.Itoa(r.References), r.Updated)
+	}
+
+	fmt.Println(t)
+	return nil
+}
+
+// yesNo renders a tri-state backup flag: unknown when the join was refused.
+func yesNo(value *bool) string {
+	switch {
+	case value == nil:
+		return ""
+	case *value:
+		return "yes"
+	default:
+		return "no"
+	}
+}
+
+func AdvisoryBackupsList(backups []sdk.AdvisoryBackupMeta) error {
+	t := ltable.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("#6667ab"))).
+		Headers("Feed", "Available", "Written").Width(TermWidth())
+
+	for _, b := range backups {
+		available := "no"
+		if b.Available {
+			available = "yes"
+		}
+		t.Row(b.Name, available, sdk.ShortDate(b.BackupWrittenAt))
+	}
+
+	fmt.Println(t)
+	return nil
+}
+
+// BackupsList renders the v3 backup catalogue (GET /v3/backup).
+//
+// Href is deliberately not a column: it is api.vulncheck.com/v3/backup/<name>
+// for every row, so it spends a third of the terminal width restating the name.
+// --json still carries it.
+func BackupsList(backups []sdk.BackupsMeta) error {
+	t := ltable.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("#6667ab"))).
+		Headers("Name", "Description").Width(TermWidth())
+
+	for _, b := range backups {
+		t.Row(b.Name, b.Description)
+	}
+
+	fmt.Println(t)
+	return nil
+}

--- a/pkg/ui/advisory_test.go
+++ b/pkg/ui/advisory_test.go
@@ -1,0 +1,133 @@
+package ui
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/vulncheck-oss/cli/pkg/sdk"
+)
+
+var testFeeds = []sdk.AdvisoryFeedMeta{
+	{Name: "epss", Href: "http://api.vulncheck.com/v4/advisory?name=epss"},
+	{Name: "ghsa", Href: "http://api.vulncheck.com/v4/advisory?name=ghsa"},
+	{Name: "sigmahq-sigma-rules"},
+}
+
+// --json is the payload untouched everywhere else, so the row must stay a
+// superset of what /v4/advisory/list returned rather than dropping href.
+func TestAdvisoryFeedsCarriesHrefThrough(t *testing.T) {
+	rows := AdvisoryFeeds(testFeeds, nil, "")
+	if rows[0].Href != "http://api.vulncheck.com/v4/advisory?name=epss" {
+		t.Errorf("Href = %q, want the API's value", rows[0].Href)
+	}
+}
+
+// An empty result must marshal as [] like advisory list, not null.
+func TestAdvisoryFeedsReturnsAnEmptySliceNotNil(t *testing.T) {
+	rows := AdvisoryFeeds(testFeeds, nil, "zzzznomatch")
+	if rows == nil {
+		t.Fatal("rows must not be nil")
+	}
+	if len(rows) != 0 {
+		t.Errorf("rows = %v, want empty", rows)
+	}
+}
+
+// v4 backup is a separate entitlement from v4 advisory -- a trial grants the
+// latter but not the former -- so the join must degrade rather than fail a
+// discovery command the caller is entitled to run.
+func TestAdvisoryFeedsDegradesWithoutBackups(t *testing.T) {
+	rows := AdvisoryFeeds(testFeeds, nil, "")
+
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(rows))
+	}
+	for _, row := range rows {
+		if row.Available != nil {
+			t.Errorf("%s: Available = %v, want nil when the join was unavailable", row.Name, *row.Available)
+		}
+		if row.BackupWrittenAt != "" {
+			t.Errorf("%s: BackupWrittenAt = %q, want empty", row.Name, row.BackupWrittenAt)
+		}
+	}
+}
+
+func TestAdvisoryFeedsJoinsBackupAvailability(t *testing.T) {
+	backups := []sdk.AdvisoryBackupMeta{
+		{Name: "epss", Available: true, BackupWrittenAt: "2026-09-02T16:17:49Z"},
+		{Name: "ghsa", Available: false},
+	}
+
+	rows := AdvisoryFeeds(testFeeds, backups, "")
+
+	if rows[0].Available == nil || !*rows[0].Available {
+		t.Error("epss should report an available backup")
+	}
+	if rows[0].BackupWrittenAt != "2026-09-02" {
+		t.Errorf("BackupWrittenAt = %q, want the date only", rows[0].BackupWrittenAt)
+	}
+	if rows[1].Available == nil || *rows[1].Available {
+		t.Error("ghsa should report no available backup")
+	}
+	// A feed absent from the backup list is unknown, not unavailable.
+	if rows[2].Available != nil {
+		t.Error("a feed missing from the backup list should stay unknown")
+	}
+}
+
+// v4 backup is a separate entitlement from v4 advisory, so the JSON key set
+// must not depend on whether the join succeeded -- a script parsing available
+// should see null, not a missing field.
+func TestAdvisoryFeedsJSONShapeIsIndependentOfEntitlement(t *testing.T) {
+	withJoin, err := json.Marshal(AdvisoryFeeds(testFeeds, []sdk.AdvisoryBackupMeta{{Name: "epss", Available: true}}, "")[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutJoin, err := json.Marshal(AdvisoryFeeds(testFeeds, nil, "")[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keys := func(raw []byte) []string {
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatal(err)
+		}
+		out := make([]string, 0, len(m))
+		for k := range m {
+			out = append(out, k)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	a, b := keys(withJoin), keys(withoutJoin)
+	if strings.Join(a, ",") != strings.Join(b, ",") {
+		t.Errorf("key sets differ: with join %v, without %v", a, b)
+	}
+	if !strings.Contains(string(withoutJoin), `"available":null`) {
+		t.Errorf("unknown availability should be null, got %s", withoutJoin)
+	}
+}
+
+func TestAdvisoryFeedsFiltersBySearch(t *testing.T) {
+	rows := AdvisoryFeeds(testFeeds, nil, "sigma")
+	if len(rows) != 1 || rows[0].Name != "sigmahq-sigma-rules" {
+		t.Errorf("rows = %v, want just sigmahq-sigma-rules", rows)
+	}
+}
+
+func TestYesNoIsTriState(t *testing.T) {
+	yes, no := true, false
+	if got := yesNo(nil); got != "" {
+		t.Errorf("yesNo(nil) = %q, want empty", got)
+	}
+	if got := yesNo(&yes); got != "yes" {
+		t.Errorf("yesNo(true) = %q, want yes", got)
+	}
+	if got := yesNo(&no); got != "no" {
+		t.Errorf("yesNo(false) = %q, want no", got)
+	}
+}


### PR DESCRIPTION
Adds V4 API support to the CLI

## Querying example

Example querying for a CVE in a speicfic index in v3 and across the whole of the v4 advisory index.

```
$ vulncheck index list ghsa --cve CVE-2019-12255     # v3

$ vulncheck advisory list --cve CVE-2019-12255       # v4
```

The v4 surface mirrors the existing v3 one:

|  | v3 - unchanged | v4 - new |
|---|---|---|
| catalogue | `indices list [search]` | `advisory feeds [search]` |
| query | `index list <index> [flags]` | `advisory list [flags]` |
| browse | `index browse <index> [flags]` | `advisory browse [flags]` |
| backup | `backup url\|download <index>` | `backup advisory url\|download <feed>` |
| backup catalogue | `backup list` | `backup advisory list` |

`advisory list` takes no positional argument because v4 is a single index

(`backup list` is v3, and exposes an SDK method that has existed but wasn't made available until now.)


## Backup example

```
$ vulncheck backup url ghsa                          # v3
Filename: ghsa-1788772522710250107.zip
Date Added: 2026-09-07T09:15:22.71Z
URL: …/latest/ghsa-1788772522710250107.zip?…

$ vulncheck backup advisory url ghsa                 # v4
Feed: ghsa
Corpus: v4-advisory
Format: zip/jsonl
URL: …/v4DataBackups/ghsa.zip?…
```

## Other notes for review

`sdk.MetaError` typed `error` as a bool, but v4 sends `{"error": "<string>"}`, so its messages were being dropped. Added an `UnmarshalJSON` that promotes the string into `Errors`, plus `case 402` in `fromReqError` so entitlement failures exit 3 (auth) not 2 (bad request).

`/v4/advisory` fails silently in three ways: an unrecognised parameter returns 200 with zero results, so a typo'd flag is indistinguishable from "no matches"; paging past 10,000 results returns a 503; and `page` is ignored when a cursor is set, returning page 1 while `_meta.page` says otherwise. The CLI rejects all three inputs before sending a request, so you get a real error rather than a response you cannot trust. (This should be revisitied when this behaviour is fixed in the api.)

## Testing

`go test ./...`, `-race`, `go vet` and `golangci-lint` are clean, and every command is
smoke-tested against production api.

The entitlement path is verified live with a community token - all four v4 endpoints return 402.