### PR TITLE
feat: report components a scan could not assess (product#3503)

### DIFF
--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -479,9 +479,19 @@ func GetBatchVulns(ctx context.Context, purls []models.PurlDetail, iterator func
 		iterator(start, total)
 	}
 
-	// Backstop: the API returns hits in non-deterministic order, and
-	// vulncheck-oss/action hashes output.json to dedupe PR comments. Being fixed
-	// upstream too.
+	SortResults(vulns)
+	slices.SortFunc(unprocessed, func(a, b models.UnprocessedComponent) int {
+		return cmp.Compare(a.Purl, b.Purl)
+	})
+
+	return vulns, unprocessed, nil
+}
+
+// SortResults orders findings so output.json is stable between identical scans;
+// vulncheck-oss/action hashes it to dedupe PR comments. Neither source
+// guarantees an order: the API dedupes through a map, and the offline queries
+// carry no ORDER BY.
+func SortResults(vulns []models.ScanResultVulnerabilities) {
 	slices.SortFunc(vulns, func(a, b models.ScanResultVulnerabilities) int {
 		if c := cmp.Compare(a.Name, b.Name); c != 0 {
 			return c
@@ -491,11 +501,6 @@ func GetBatchVulns(ctx context.Context, purls []models.PurlDetail, iterator func
 		}
 		return cmp.Compare(a.CVE, b.CVE)
 	})
-	slices.SortFunc(unprocessed, func(a, b models.UnprocessedComponent) int {
-		return cmp.Compare(a.Purl, b.Purl)
-	})
-
-	return vulns, unprocessed, nil
 }
 
 func GetVulns(ctx context.Context, purls []models.PurlDetail, iterator func(cur int, total int)) ([]models.ScanResultVulnerabilities, error) {

--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -1,11 +1,13 @@
 package bill
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/anchore/syft/syft"
@@ -476,6 +478,22 @@ func GetBatchVulns(ctx context.Context, purls []models.PurlDetail, iterator func
 
 		iterator(start, total)
 	}
+
+	// Backstop: the API returns hits in non-deterministic order, and
+	// vulncheck-oss/action hashes output.json to dedupe PR comments. Being fixed
+	// upstream too.
+	slices.SortFunc(vulns, func(a, b models.ScanResultVulnerabilities) int {
+		if c := cmp.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.Version, b.Version); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.CVE, b.CVE)
+	})
+	slices.SortFunc(unprocessed, func(a, b models.UnprocessedComponent) int {
+		return cmp.Compare(a.Purl, b.Purl)
+	})
 
 	return vulns, unprocessed, nil
 }

--- a/pkg/bill/bill.go
+++ b/pkg/bill/bill.go
@@ -428,10 +428,14 @@ func GetPURLDetail(sbm *sbom.SBOM, inputRefs []InputSbomRef) []models.PurlDetail
 	return purls
 }
 
-func GetBatchVulns(ctx context.Context, purls []models.PurlDetail, iterator func(cur int, total int)) ([]models.ScanResultVulnerabilities, error) {
+// GetBatchVulns looks up every purl and also returns the components the API
+// could not assess. Those never appear in the findings, so a caller that
+// ignores the second return cannot tell a partial scan from a clean one.
+func GetBatchVulns(ctx context.Context, purls []models.PurlDetail, iterator func(cur int, total int)) ([]models.ScanResultVulnerabilities, []models.UnprocessedComponent, error) {
 	const batchSize = 100
 
 	var vulns []models.ScanResultVulnerabilities
+	var unprocessed []models.UnprocessedComponent
 
 	purlStrings := make([]string, 0, len(purls))
 	for _, purl := range purls {
@@ -447,7 +451,7 @@ func GetBatchVulns(ctx context.Context, purls []models.PurlDetail, iterator func
 
 		response, err := session.ConnectWithContext(ctx, config.Token()).GetPurls(batch)
 		if err != nil {
-			return nil, fmt.Errorf("error fetching purls %v: %w", batch, err)
+			return nil, nil, fmt.Errorf("error fetching purls %v: %w", batch, err)
 		}
 
 		for _, purlResponse := range response.PurlData {
@@ -460,10 +464,20 @@ func GetBatchVulns(ctx context.Context, purls []models.PurlDetail, iterator func
 				})
 			}
 		}
+
+		// Empty against an API predating partial results, where an unusable purl
+		// failed the whole batch rather than being reported.
+		for _, item := range response.Meta.Unprocessed {
+			unprocessed = append(unprocessed, models.UnprocessedComponent{
+				Purl:   item.Purl,
+				Reason: item.Reason,
+			})
+		}
+
 		iterator(start, total)
 	}
 
-	return vulns, nil
+	return vulns, unprocessed, nil
 }
 
 func GetVulns(ctx context.Context, purls []models.PurlDetail, iterator func(cur int, total int)) ([]models.ScanResultVulnerabilities, error) {

--- a/pkg/bill/bill_test.go
+++ b/pkg/bill/bill_test.go
@@ -1,8 +1,14 @@
 package bill
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -10,6 +16,8 @@ import (
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/vulncheck-oss/cli/pkg/cache"
+	"github.com/vulncheck-oss/cli/pkg/config"
+	"github.com/vulncheck-oss/cli/pkg/environment"
 	"github.com/vulncheck-oss/cli/pkg/models"
 )
 
@@ -560,4 +568,106 @@ func TestEnrichAllDoesNotEnableVcpkgCloning(t *testing.T) {
 	if pkgcataloging.DefaultConfig().Cpp.VcpkgAllowGitClone {
 		t.Error("syft's default config now enables vcpkg git cloning; the --enrich rejection is no longer sufficient")
 	}
+}
+
+// pointAtStub routes GetBatchVulns at a local server. session.Connect reads the
+// exported environment.Env.API, so overriding it is enough; the token only has
+// to be non-empty to satisfy config.ValidToken.
+func pointAtStub(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	previous := environment.Env.API
+	environment.Env.API = srv.URL
+	t.Cleanup(func() { environment.Env.API = previous })
+
+	t.Setenv(config.EnvToken, "vulncheck_test_token")
+}
+
+func noProgress(_ int, _ int) {}
+
+func TestGetBatchVulns(t *testing.T) {
+	t.Run("reports unprocessed components alongside findings", func(t *testing.T) {
+		pointAtStub(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = fmt.Fprint(w, `{"_meta":{"total_documents":1,"total_submitted":2,`+
+				`"unprocessed":[{"purl":"pkg:generic/openssl@1.1.1","reason":"unsupported_type"}]},`+
+				`"data":[{"purl":"pkg:hex/coherence@0.1.2","purl_struct":{"name":"coherence","version":"0.1.2"},`+
+				`"vulnerabilities":[{"detection":"CVE-2018-20301","fixed_version":"0.5.2"}]}]}`)
+		})
+
+		vulns, unprocessed, err := GetBatchVulns(context.Background(), []models.PurlDetail{
+			{Purl: "pkg:hex/coherence@0.1.2"},
+			{Purl: "pkg:generic/openssl@1.1.1"},
+		}, noProgress)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(vulns) != 1 || vulns[0].CVE != "CVE-2018-20301" {
+			t.Fatalf("expected the one finding to survive, got %+v", vulns)
+		}
+		want := []models.UnprocessedComponent{
+			{Purl: "pkg:generic/openssl@1.1.1", Reason: "unsupported_type"},
+		}
+		if !reflect.DeepEqual(unprocessed, want) {
+			t.Errorf("unprocessed: got %+v, want %+v", unprocessed, want)
+		}
+	})
+
+	// batchSize is 100, so 101 purls means two round-trips. Each reports one
+	// unusable component and both must survive; accumulating only the last
+	// batch's would silently under-report on any large SBOM.
+	t.Run("accumulates unprocessed across batches", func(t *testing.T) {
+		var calls int
+		pointAtStub(t, func(w http.ResponseWriter, r *http.Request) {
+			var batch []string
+			_ = json.NewDecoder(r.Body).Decode(&batch)
+			calls++
+			_, _ = fmt.Fprintf(w, `{"_meta":{"total_documents":0,"total_submitted":%d,`+
+				`"unprocessed":[{"purl":"pkg:generic/batch-%d@1.0.0","reason":"unsupported_type"}]},`+
+				`"data":[]}`, len(batch), calls)
+		})
+
+		purls := make([]models.PurlDetail, 0, 101)
+		for i := 0; i < 101; i++ {
+			purls = append(purls, models.PurlDetail{Purl: fmt.Sprintf("pkg:npm/pkg-%d@1.0.0", i)})
+		}
+
+		vulns, unprocessed, err := GetBatchVulns(context.Background(), purls, noProgress)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(vulns) != 0 {
+			t.Errorf("expected no findings, got %d", len(vulns))
+		}
+		if calls != 2 {
+			t.Fatalf("expected 101 purls to span 2 batches, got %d calls", calls)
+		}
+		want := []models.UnprocessedComponent{
+			{Purl: "pkg:generic/batch-1@1.0.0", Reason: "unsupported_type"},
+			{Purl: "pkg:generic/batch-2@1.0.0", Reason: "unsupported_type"},
+		}
+		if !reflect.DeepEqual(unprocessed, want) {
+			t.Errorf("unprocessed: got %+v, want %+v", unprocessed, want)
+		}
+	})
+
+	t.Run("returns nothing unprocessed against an API that omits the field", func(t *testing.T) {
+		pointAtStub(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = fmt.Fprint(w, `{"_meta":{"total_documents":0},"data":[]}`)
+		})
+
+		vulns, unprocessed, err := GetBatchVulns(context.Background(),
+			[]models.PurlDetail{{Purl: "pkg:hex/coherence@0.1.2"}}, noProgress)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(vulns) != 0 {
+			t.Errorf("expected no findings, got %d", len(vulns))
+		}
+		if len(unprocessed) != 0 {
+			t.Errorf("expected nothing unprocessed, got %+v", unprocessed)
+		}
+	})
 }

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -211,6 +211,7 @@ func Command() *cobra.Command {
 								purlVulns = results
 								t.Title = fmt.Sprintf(i18n.C.ScanScanPurlEndOffline, len(purlVulns), len(purls))
 								vulns = append(cpeVulns, purlVulns...)
+								bill.SortResults(vulns)
 								result = models.ScanResult{
 									Vulnerabilities: vulns,
 									Unprocessed:     unprocessed,

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -24,10 +24,11 @@ import (
 // --sbom-only, so agents can tell a "successful no-vuln-lookup" run
 // apart from a normal empty-result run.
 type scanEnvelope struct {
-	SchemaVersion   int                                 `json:"schema_version"`
-	Vulnerabilities []models.ScanResultVulnerabilities  `json:"vulnerabilities,omitempty"`
-	SbomOnly        bool                                `json:"sbom_only,omitempty"`
-	SbomOutputFile  string                              `json:"sbom_output_file,omitempty"`
+	SchemaVersion   int                                `json:"schema_version"`
+	Vulnerabilities []models.ScanResultVulnerabilities `json:"vulnerabilities,omitempty"`
+	SbomOnly        bool                               `json:"sbom_only,omitempty"`
+	SbomOutputFile  string                             `json:"sbom_output_file,omitempty"`
+	Unprocessed     []models.UnprocessedComponent      `json:"unprocessed,omitempty"`
 }
 
 type Options struct {
@@ -91,6 +92,10 @@ func Command() *cobra.Command {
 			var cpeVulns []models.ScanResultVulnerabilities
 			var purlVulns []models.ScanResultVulnerabilities
 			var vulns []models.ScanResultVulnerabilities
+			// unprocessed holds components the API could not assess. They are
+			// absent from vulns entirely, so without reporting them a partial
+			// scan is indistinguishable from a clean one.
+			var unprocessed []models.UnprocessedComponent
 			// metaAvailable tracks whether the vulncheck-nvd2 index was
 			// usable. When --offline-meta is requested but the index is
 			// missing (with --warn-on-index), we still surface the CVEs
@@ -208,6 +213,7 @@ func Command() *cobra.Command {
 								vulns = append(cpeVulns, purlVulns...)
 								result = models.ScanResult{
 									Vulnerabilities: vulns,
+									Unprocessed:     unprocessed,
 								}
 								return nil
 							},
@@ -232,6 +238,7 @@ func Command() *cobra.Command {
 									}
 									result = models.ScanResult{
 										Vulnerabilities: vulns,
+										Unprocessed:     unprocessed,
 									}
 									return nil
 								},
@@ -244,7 +251,7 @@ func Command() *cobra.Command {
 							Title: i18n.C.ScanScanPurlStart,
 							Task: func(t *taskin.Task) error {
 								purlVulns = []models.ScanResultVulnerabilities{}
-								results, err := bill.GetBatchVulns(ctx, purls, func(cur int, total int) {
+								results, skipped, err := bill.GetBatchVulns(ctx, purls, func(cur int, total int) {
 									t.Title = fmt.Sprintf(i18n.C.ScanScanPurlProgress, cur, total)
 									t.Progress(cur, total)
 								})
@@ -252,7 +259,12 @@ func Command() *cobra.Command {
 									return err
 								}
 								purlVulns = results
+								unprocessed = skipped
 								t.Title = fmt.Sprintf(i18n.C.ScanScanPurlEnd, len(purlVulns), len(purls))
+								if len(unprocessed) > 0 {
+									t.Title = fmt.Sprintf(i18n.C.ScanScanPurlEndPartial,
+										len(purlVulns), len(purls)-len(unprocessed), len(purls))
+								}
 								vulns = purlVulns
 								return nil
 							},
@@ -268,6 +280,7 @@ func Command() *cobra.Command {
 								t.Title = i18n.C.ScanVulnMetaEnd
 								result = models.ScanResult{
 									Vulnerabilities: vulns,
+									Unprocessed:     unprocessed,
 								}
 								return nil
 							},
@@ -346,6 +359,7 @@ func Command() *cobra.Command {
 				return r.JSON(scanEnvelope{
 					SchemaVersion:   output.SchemaVersion,
 					Vulnerabilities: result.Vulnerabilities,
+					Unprocessed:     result.Unprocessed,
 				})
 			}
 
@@ -360,6 +374,24 @@ func Command() *cobra.Command {
 				}
 				if opts.OfflineMeta && !metaAvailable {
 					r.Info("%s", i18n.C.ScanVulnOfflineMetaUnavailable)
+				}
+			}
+
+			// Outside the if/else above: an incomplete scan needs stating
+			// whether or not anything was found. All of it goes through Warn so
+			// the header and the list stay on one stream and survive --quiet.
+			if len(result.Unprocessed) > 0 {
+				r.Warn(i18n.C.ScanUnprocessed, len(result.Unprocessed), len(purls))
+
+				// A large SBOM can skip hundreds; the full list is in the JSON
+				// output rather than flooding the terminal with it.
+				const shown = 10
+				for i, item := range result.Unprocessed {
+					if i == shown {
+						r.Warn(i18n.C.ScanUnprocessedMore, len(result.Unprocessed)-shown)
+						break
+					}
+					r.Warn("  %s (%s)", item.Purl, item.Reason)
 				}
 			}
 

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -136,6 +136,9 @@ type Copy struct {
 	ScanScanPurlProgress        string
 	ScanScanPurlProgressOffline string
 	ScanScanPurlEnd             string
+	ScanScanPurlEndPartial      string
+	ScanUnprocessed             string
+	ScanUnprocessedMore         string
 	ScanScanPurlEndOffline      string
 	ScanExtractCpeStart         string
 	ScanExtractCpeEnd           string
@@ -326,6 +329,9 @@ var En = Copy{
 	ScanScanPurlProgress:        "Scanning PURLs [%d/%d]",
 	ScanScanPurlProgressOffline: "[OFFLINE] Scanning PURLs [%d/%d]",
 	ScanScanPurlEnd:             "Scanning PURLs: %d vulns found in %d packages",
+	ScanScanPurlEndPartial:      "Scanning PURLs: %d vulns found in %d of %d packages",
+	ScanUnprocessed:             "%d of %d components could not be assessed and are not counted above:",
+	ScanUnprocessedMore:         "  ...and %d more (see the scan output file for the full list)",
 	ScanScanPurlEndOffline:      "[OFFLINE] Scanning PURLs: %d vulns found in %d packages",
 
 	ScanScanCpeStartOffline:    "[OFFLINE] Scanning CPEs",

--- a/pkg/models/scan.go
+++ b/pkg/models/scan.go
@@ -7,9 +7,8 @@ import (
 type ScanResult struct {
 	Vulnerabilities []ScanResultVulnerabilities `json:"vulnerabilities"`
 
-	// Unprocessed lists components the scan could not assess. Omitted when
-	// empty, so a scan that skipped nothing serialises byte-for-byte as before
-	// — vulncheck-oss/action hashes this whole document to dedupe PR comments.
+	// Omitted when empty: this field alone must not change the document
+	// vulncheck-oss/action hashes to dedupe PR comments.
 	Unprocessed []UnprocessedComponent `json:"unprocessed,omitempty"`
 }
 

--- a/pkg/models/scan.go
+++ b/pkg/models/scan.go
@@ -6,6 +6,22 @@ import (
 
 type ScanResult struct {
 	Vulnerabilities []ScanResultVulnerabilities `json:"vulnerabilities"`
+
+	// Unprocessed lists components the scan could not assess. Omitted when
+	// empty, so a scan that skipped nothing serialises byte-for-byte as before
+	// — vulncheck-oss/action hashes this whole document to dedupe PR comments.
+	Unprocessed []UnprocessedComponent `json:"unprocessed,omitempty"`
+}
+
+// UnprocessedComponent is a component the scan could not assess, and why. These
+// never appear in Vulnerabilities, so without reporting them a partial scan
+// reads as a clean one.
+type UnprocessedComponent struct {
+	Purl string `json:"purl"`
+
+	// Passed through from the API. An open set; as of writing
+	// "unsupported_type", "unparseable" or "unsupported_distro".
+	Reason string `json:"reason"`
 }
 
 type PurlDetail struct {

--- a/pkg/parity/parity_test.go
+++ b/pkg/parity/parity_test.go
@@ -137,9 +137,17 @@ func TestPURLParity(t *testing.T) {
 
 			detail := []models.PurlDetail{{Purl: p}}
 
-			onlineVulns, err := bill.GetBatchVulns(ctx, detail, noopProgress)
+			onlineVulns, unprocessed, err := bill.GetBatchVulns(ctx, detail, noopProgress)
 			if err != nil {
 				t.Fatalf("online lookup: %v", err)
+			}
+			// A purl the API cannot assess returns no findings, and offline
+			// returns none either, so the CVE sets would agree trivially and the
+			// row would pass for the wrong reason. Skip rather than bank a false
+			// match.
+			if len(unprocessed) > 0 {
+				t.Skipf("API could not assess this purl: %s (%s)",
+					unprocessed[0].Purl, unprocessed[0].Reason)
 			}
 			offlineVulns, err := bill.GetOfflineVulns(indices, detail, noopProgress, false)
 			if err != nil {

--- a/pkg/sdk/purl.go
+++ b/pkg/sdk/purl.go
@@ -42,11 +42,26 @@ type BatchPurlData struct {
 	Vulnerabilities []PurlVulnerability `json:"vulnerabilities"`
 }
 
+// UnprocessedPurl is a purl the API could not look up. Reason is passed through
+// verbatim and should be treated as an open set; as of writing it is
+// "unsupported_type" (a valid purl for an ecosystem VulnCheck does not index),
+// "unparseable" (not a valid purl), or "unsupported_distro" (a distro-scoped
+// purl whose distro qualifier is missing or unrecognised).
+type UnprocessedPurl struct {
+	Purl   string `json:"purl"`
+	Reason string `json:"reason"`
+}
+
 type PurlsResponse struct {
 	Benchmark float64 `json:"_benchmark"`
 	Meta      struct {
 		Timestamp      string  `json:"timestamp"`
 		TotalDocuments float64 `json:"total_documents"`
+		TotalSubmitted float64 `json:"total_submitted"`
+
+		// Absent on API versions predating partial results, where an unusable
+		// purl failed the whole batch instead of being reported.
+		Unprocessed []UnprocessedPurl `json:"unprocessed"`
 	} `json:"_meta"`
 	PurlData []BatchPurlData `json:"data"`
 }

--- a/pkg/sdk/purl_test.go
+++ b/pkg/sdk/purl_test.go
@@ -39,3 +39,71 @@ func TestGetPurl(t *testing.T) {
 		assert.Equal(t, "CVE-2018-20301", purlResp.Data.Cves[0])
 	})
 }
+
+// TestGetPurls covers the batch endpoint, which had no test. The _meta fields
+// matter most: dropping them silently is how a partial scan would come back
+// looking complete.
+func TestGetPurls(t *testing.T) {
+	t.Run("decodes findings alongside unprocessed purls", func(t *testing.T) {
+		body := `{"_benchmark":0.01,"_meta":{"timestamp":"2026-09-11T00:00:00Z",` +
+			`"total_documents":1,"total_submitted":3,"unprocessed":[` +
+			`{"purl":"pkg:generic/openssl@1.1.1","reason":"unsupported_type"},` +
+			`{"purl":"not-a-purl-at-all","reason":"unparseable"}]},` +
+			`"data":[{"purl":"pkg:hex/coherence@0.1.2","purl_struct":{"name":"coherence","version":"0.1.2"},` +
+			`"cves":["CVE-2018-20301"],"vulnerabilities":[{"detection":"CVE-2018-20301","fixed_version":"0.5.2"}]}]}`
+
+		var gotBody []byte
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotBody, _ = io.ReadAll(r.Body)
+			_, _ = fmt.Fprint(w, body)
+		}))
+		defer srv.Close()
+
+		resp, err := Connect(srv.URL, "tok").GetPurls([]string{
+			"pkg:hex/coherence@0.1.2",
+			"pkg:generic/openssl@1.1.1",
+			"not-a-purl-at-all",
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// the endpoint takes a bare JSON array, not an object
+		assert.JSONEq(t,
+			`["pkg:hex/coherence@0.1.2","pkg:generic/openssl@1.1.1","not-a-purl-at-all"]`,
+			string(gotBody))
+
+		assert.Len(t, resp.PurlData, 1)
+		assert.Equal(t, "pkg:hex/coherence@0.1.2", resp.PurlData[0].Purl)
+		assert.Equal(t, float64(3), resp.Meta.TotalSubmitted)
+		assert.Equal(t, []UnprocessedPurl{
+			{Purl: "pkg:generic/openssl@1.1.1", Reason: "unsupported_type"},
+			{Purl: "not-a-purl-at-all", Reason: "unparseable"},
+		}, resp.Meta.Unprocessed)
+	})
+
+	t.Run("tolerates an API that does not report unprocessed purls", func(t *testing.T) {
+		body := `{"_benchmark":0.01,"_meta":{"timestamp":"2026-09-11T00:00:00Z","total_documents":0},"data":[]}`
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = fmt.Fprint(w, body)
+		}))
+		defer srv.Close()
+
+		resp, err := Connect(srv.URL, "tok").GetPurls([]string{"pkg:hex/coherence@0.1.2"})
+		assert.NoError(t, err)
+		assert.Empty(t, resp.Meta.Unprocessed)
+		assert.Zero(t, resp.Meta.TotalSubmitted)
+	})
+
+	t.Run("surfaces a non-200 as an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(w, `{"error":true,"errors":["boom"]}`)
+		}))
+		defer srv.Close()
+
+		resp, err := Connect(srv.URL, "tok").GetPurls([]string{"pkg:hex/coherence@0.1.2"})
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}


### PR DESCRIPTION
`POST /v3/purls` now returns partial results for a batch containing unusable PURLs and lists the rest in `_meta.unprocessed`. The CLI dropped that field and skipped components don't appear in the findings either - an empty result looked the same regardless if it was a clean scan or an purl we couldn't process. 

`bill.GetBatchVulns` now returns those components alongside the findings, and `scan` reports them in `output.json`, `--json`, the task progress line (`%d vulns found in %d of %d packages`) and the text summary (capped at ten, with the full list in the JSON, all via `Renderer.Warn` so it survives `--quiet` on one stream.)
Findings are now sorted, which is required for the github action.

Compatible in both directions: against an API without the field nothing is reported and output is unchanged, so this can merge either side of the API deployment. 

Verified end to end against staging with a mixed SBOM: 2 of 5 components resolved to 9 CVEs, the other 3 reported as `unsupported_type` / `unsupported_distro`.